### PR TITLE
Rename match/execute to conditions/actions

### DIFF
--- a/docs/api/condition.md
+++ b/docs/api/condition.md
@@ -16,7 +16,7 @@ Conditions define when a rule should fire. Ruleur provides composable condition 
 All child conditions must be true.
 
 ```ruby
-match do
+conditions do
   all?(
     user(:admin?),
     record(:published?),
@@ -30,7 +30,7 @@ end
 At least one child condition must be true.
 
 ```ruby
-match do
+conditions do
   any?(
     user(:admin?),
     user(:owner?, record)
@@ -43,7 +43,7 @@ end
 Inverts the child condition.
 
 ```ruby
-match do
+conditions do
   all?(
     not?(record(:archived?)),
     record(:active?)
@@ -153,7 +153,7 @@ See [Operators](./operators) for a complete list of available comparison operato
 Conditions can be nested to arbitrary depth:
 
 ```ruby
-match do
+conditions do
   any?(
     all?(
       user(:admin?),
@@ -212,11 +212,11 @@ not?(record(:draft?))
 
 ```ruby
 rule 'admin_only' do
-  match do
+  conditions do
     all?(user(:admin?))
   end
 
-  execute do
+  actions do
     allow! :access
   end
 end
@@ -226,14 +226,14 @@ end
 
 ```ruby
 rule 'bulk_discount' do
-  match do
+  conditions do
     all?(
       order(:total).gt?(500),
       order(:items_count).gt?(10)
     )
   end
 
-  execute do
+  actions do
     set :discount, 0.15
   end
 end
@@ -243,7 +243,7 @@ end
 
 ```ruby
 rule 'can_edit' do
-  match do
+  conditions do
     any?(
       # Admin can always edit
       user(:admin?),
@@ -259,7 +259,7 @@ rule 'can_edit' do
     )
   end
 
-  execute do
+  actions do
     allow! :edit
   end
 end
@@ -269,7 +269,7 @@ end
 
 ```ruby
 rule 'premium_feature' do
-  match do
+  conditions do
     all?(
       user(:subscription, :active?),
       user(:subscription, :tier).eq?('premium'),
@@ -278,7 +278,7 @@ rule 'premium_feature' do
     )
   end
 
-  execute do
+  actions do
     allow! :premium_feature
   end
 end

--- a/docs/api/context.md
+++ b/docs/api/context.md
@@ -120,10 +120,10 @@ Within rule actions, the context is available and can be modified:
 
 ```ruby
 rule 'calculate_discount' do
-  match do
+  conditions do
     all?(customer(:vip?))
   end
-  execute do
+  actions do
     # Access facts
     order = context[:order]
 
@@ -153,10 +153,10 @@ Use `set :key, true` to set a result when conditions are met:
 
 ```ruby
 rule 'admin_create' do
-  match do
+  conditions do
     all?(user(:admin?))
   end
-  execute do
+  actions do
     set :create, true
   end
 end
@@ -173,7 +173,7 @@ ctx[:create].nil? # no rule set this value
 For non-permission values, use `set` with clear names:
 
 ```ruby
-execute do
+actions do
   set :discount, 0.20
   set :discount_reason, 'VIP customer'
   set :error_message, 'Something went wrong'
@@ -186,12 +186,12 @@ Avoid overwriting input facts directly:
 
 ```ruby
 # Bad
-execute do
+actions do
   context[:user] = modified_user
 end
 
 # Good
-execute do
+actions do
   set :modified_user, modified_user
   set :user_updated, true
 end
@@ -202,7 +202,7 @@ end
 Check fact presence before use:
 
 ```ruby
-execute do
+actions do
   if context.key?(:order)
     order = context[:order]
     set :total, order.total
@@ -218,13 +218,13 @@ end
 
 ```ruby
 rule 'premium_check' do
-  match do
+  conditions do
     all?(
       customer(:premium?),
       order(:total).gt?(100)
     )
   end
-  execute do
+  actions do
     customer = context[:customer]
     order = context[:order]
 
@@ -239,20 +239,20 @@ end
 ```ruby
 # First rule sets a flag
 rule 'validate_order' do
-  match do
+  conditions do
     all?(order(:valid?))
   end
-  execute do
+  actions do
     set :order_valid, true
   end
 end
 
 # Second rule depends on the flag
 rule 'process_payment' do
-  match do
+  conditions do
     all?(flag(:order_valid))
   end
-  execute do
+  actions do
     set :payment_processed, true
   end
 end

--- a/docs/api/dsl.md
+++ b/docs/api/dsl.md
@@ -39,10 +39,10 @@ Defines a rule within the engine.
 
 ```ruby
 rule 'example', salience: 10, tags: [:important], no_loop: true do
-  match do
+  conditions do
     all?(conditions)
   end
-  execute do
+  actions do
     # action code here
   end
 end
@@ -64,7 +64,7 @@ end
 All conditions must be true (AND). Wrap them in a `match` block in rules:
 
 ```ruby
-match do
+conditions do
   all?(
     user(:admin?),
     record(:published?),
@@ -78,7 +78,7 @@ end
 At least one condition must be true (OR). Wrap them in a `match` block in rules:
 
 ```ruby
-match do
+conditions do
   any?(
     user(:admin?),
     user(:owner?, record),
@@ -92,7 +92,7 @@ end
 Same as above but can be nested within `any`.
 
 ```ruby
-match do
+conditions do
   any?(
     user(:admin?),
     all?(
@@ -108,7 +108,7 @@ end
 Same as above but can be nested within `all`.
 
 ```ruby
-match do
+conditions do
   all?(
     any?(user(:admin?), user(:moderator?)),
     record(:published?)
@@ -121,7 +121,7 @@ end
 Negates a condition inside a `match` block.
 
 ```ruby
-match do
+conditions do
   all?(
     user(:active?),
     not?(user(:banned?))
@@ -183,7 +183,7 @@ order(:total).gt?(literal(100))
 Sets a value in the context.
 
 ```ruby
-execute do
+actions do
   set :discount, 0.15
   set :approved, true
   set :message, 'Order processed'
@@ -199,7 +199,7 @@ end
 Calls a method on an object.
 
 ```ruby
-execute do
+actions do
   order = context[:order]
   call_method(order, :apply_discount, 0.15)
   call_method(order, :add_note, 'Discount applied')
@@ -211,7 +211,7 @@ end
 Within action blocks, you have access to:
 
 ```ruby
-execute do
+actions do
   # Direcordt context access
   user = context[:user]
   order = context[:order]
@@ -230,20 +230,20 @@ end
 engine = Ruleur.define do
   # High priority rule
   rule 'validate_user', salience: 100 do
-    match do
+    conditions do
       all?(
         user(:present),
         not?(user(:banned?))
       )
     end
-    execute do
+    actions do
       set :user_valid, true
     end
   end
 
   # Permission rule
   rule 'allow_edit', salience: 50, tags: [:permissions] do
-    match do
+    conditions do
       any?(
         user(:admin?),
         all?(
@@ -253,7 +253,7 @@ engine = Ruleur.define do
         )
       )
     end
-    execute do
+    actions do
       set :edit, true
       set :reason, 'User has edit permissions'
     end
@@ -261,14 +261,14 @@ engine = Ruleur.define do
 
   # Workflow rule with no_loop
   rule 'process_order', salience: 10, no_loop: true do
-    match do
+    conditions do
       all?(
         flag(:user_valid),
         flag(:update),
         recordord(:ready_to_process?)
       )
     end
-    execute do
+    actions do
       order = context[:recordord]
       call_method(order, :process!)
       set :processed, true
@@ -289,10 +289,10 @@ puts result[:processed] # => true
 ```ruby
 def create_threshold_rule(name, threshold)
   rule name do
-    match do
+    conditions do
       all?(order(:total).gt?(literal(threshold)))
     end
-    execute { set :tier, name }
+    actions { set :tier, name }
   end
 end
 
@@ -307,14 +307,14 @@ end
 
 ```ruby
 rule 'premium_check' do
-  match do
+  conditions do
     all?(
       user(:subscription, :tier).eq?('premium'),
       user(:subscription, :active?),
       user(:subscription, :expires_at).gt?(literal(Date.today))
     )
   end
-  execute do
+  actions do
     set :premium_features, true
   end
 end
@@ -324,10 +324,10 @@ end
 
 ```ruby
 rule 'calculate_shipping' do
-  match do
+  conditions do
     all?(flag(:order_valid))
   end
-  execute do
+  actions do
     order = context[:order]
     total = order.total
 

--- a/docs/api/engine.md
+++ b/docs/api/engine.md
@@ -55,10 +55,10 @@ The recommended way to create an engine is using the DSL:
 ```ruby
 engine = Ruleur.define do
   rule 'rule_name' do
-    match do
+    conditions do
       all?(condition)
     end
-    execute do
+    actions do
       # action code
     end
   end

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -45,10 +45,10 @@ If you're new to Ruleur, we recommend starting with the [Getting Started Guide](
 # 1. Define rules using DSL
 engine = Ruleur.define do
   rule 'example' do
-    match do
+    conditions do
       all?(condition)
     end
-    execute do
+    actions do
       # ...
     end
   end

--- a/docs/api/operators.md
+++ b/docs/api/operators.md
@@ -186,14 +186,14 @@ calculator(:compute, value1, value2, operator: :add)
 
 ```ruby
 rule 'example' do
-  match do
+  conditions do
     all?(
       order(:total).gt?(100),
       user(:email).matches(/@company\.com$/),
       user(:roles).includes('premium')
     )
   end
-  execute do
+  actions do
     set :qualified, true
   end
 end
@@ -202,7 +202,7 @@ end
 ### In YAML
 
 ```yaml
-condition:
+conditions:
   type: all
   children:
     - type: pred
@@ -228,7 +228,7 @@ When combining operators, use explicit grouping with `all?()` and `any?()`:
 
 ```ruby
 # Clear precedence with grouping
-match do
+conditions do
   all?(
     any?(
       user(:admin?),
@@ -245,13 +245,13 @@ end
 
 ```ruby
 rule 'medium_order' do
-  match do
+  conditions do
     all?(
       order(:total).gte?(50),
       order(:total).lt?(200)
     )
   end
-  execute do
+  actions do
     set :tier, 'medium'
   end
 end
@@ -261,13 +261,13 @@ end
 
 ```ruby
 rule 'valid_email' do
-  match do
+  conditions do
     all?(
       user(:email).present,
       user(:email).matches(/\A[\w+\-.]+@[a-z\d-]+(\.[a-z\d-]+)*\.[a-z]+\z/i)
     )
   end
-  execute do
+  actions do
     set :email_valid, true
   end
 end
@@ -277,14 +277,14 @@ end
 
 ```ruby
 rule 'can_approve' do
-  match do
+  conditions do
     all?(
       user(:roles).includes('approver'),
       document(:status).in(%w[pending submitted]),
       not?(document(:approved_at).present)
     )
   end
-  execute do
+  actions do
     allow! :approve
   end
 end
@@ -294,7 +294,7 @@ end
 
 ```ruby
 rule 'process_data' do
-  match do
+  conditions do
     all?(
       input(:data).present,
       input(:data).is_a(Hash),
@@ -302,7 +302,7 @@ rule 'process_data' do
       not?(input(:data, :items).blank)
     )
   end
-  execute do
+  actions do
     set :ready_to_process, true
   end
 end

--- a/docs/api/repositories.md
+++ b/docs/api/repositories.md
@@ -250,10 +250,10 @@ repo = Ruleur::Persistence::Repository::ActiveRecord.new
 # Save a rule
 rule = Ruleur.define do
   rule 'discount' do
-    match do
+    conditions do
       all?(order(:total).gt?(100))
     end
-    execute do
+    actions do
       set :discount, 0.1
     end
   end

--- a/docs/api/rule.md
+++ b/docs/api/rule.md
@@ -102,13 +102,13 @@ The recommended way to create rules is using the DSL within `Ruleur.define`:
 ```ruby
 engine = Ruleur.define do
   rule 'discount_rule', salience: 10, tags: [:pricing] do
-    match do
+    conditions do
       all?(
         customer(:vip?),
         order(:total).gt?(100)
       )
     end
-    execute do
+    actions do
       set :discount, 0.2
       set :discount_applied, true
     end
@@ -148,7 +148,7 @@ Prevents a rule from firing again after it modifies facts:
 
 ```ruby
 rule 'counter', no_loop: true do
-  execute do
+  actions do
     increment :count
   end
 end
@@ -160,7 +160,7 @@ end
 
 ```ruby
 rule 'shipping_discount' do
-  match do
+  conditions do
     all?(
       order(:total).gt?(50),
       any?(
@@ -169,7 +169,7 @@ rule 'shipping_discount' do
       )
     )
   end
-  execute do
+  actions do
     set :free_shipping, true
   end
 end
@@ -179,13 +179,13 @@ end
 
 ```ruby
 rule 'approval_workflow' do
-  match do
+  conditions do
     all?(
       document(:ready_for_review?),
       not?(document(:approved?))
     )
   end
-  execute do
+  actions do
     call_method document, :mark_pending_review
     set :notification_sent, send_notification(document)
     set :approval_required, true

--- a/docs/api/validation.md
+++ b/docs/api/validation.md
@@ -126,7 +126,7 @@ result = Ruleur::Validation.validate(rule)
 
 ```ruby
 # Contradictory conditions
-match do
+conditions do
   all?(
     user(:admin?),
     not?(user(:admin?))
@@ -135,7 +135,7 @@ end
 # => Warning: "Contradictory conditions detected"
 
 # Unreachable condition
-match do
+conditions do
   all?(
     lit(false),
     user(:admin?)
@@ -151,10 +151,10 @@ end
 ```ruby
 engine = Ruleur.define do
   rule 'example' do
-    match do
+    conditions do
       all?(user(:admin?))
     end
-    execute do
+    actions do
       allow! :access
     end
   end

--- a/docs/api/yaml-loader.md
+++ b/docs/api/yaml-loader.md
@@ -75,9 +75,9 @@ name: rule_name
 salience: 10
 tags: [tag1, tag2]
 no_loop: true
-condition:
+conditions:
   # condition tree
-action:
+actions:
   # action definition
 ```
 
@@ -86,7 +86,7 @@ action:
 #### All (AND)
 
 ```yaml
-condition:
+conditions:
   type: all
   children:
     - type: pred
@@ -106,7 +106,7 @@ condition:
 #### Any (OR)
 
 ```yaml
-condition:
+conditions:
   type: any
   children:
     - type: pred
@@ -118,7 +118,7 @@ condition:
 #### Not (Negation)
 
 ```yaml
-condition:
+conditions:
   type: not
   child:
     type: pred
@@ -128,7 +128,7 @@ condition:
 #### Predicate with Operator
 
 ```yaml
-condition:
+conditions:
   type: pred
   op: greater_than
   left:
@@ -143,7 +143,7 @@ condition:
 ### Action Format
 
 ```yaml
-action:
+actions:
   set:
     discount: 0.15
     approved: true
@@ -164,14 +164,14 @@ name: admin_access
 salience: 100
 tags: [permissions, admin]
 no_loop: false
-condition:
+conditions:
   type: pred
   op: truthy
   left:
     type: call
     recv: { type: ref, root: user }
     method: admin?
-action:
+actions:
   set:
     allow_access: true
     access_level: "full"
@@ -193,7 +193,7 @@ result = engine.run(user: current_user)
 name: can_edit
 salience: 50
 tags: [permissions, edit]
-condition:
+conditions:
   type: any
   children:
     # Admin can always edit
@@ -224,7 +224,7 @@ condition:
               type: call
               recv: { type: ref, root: record }
               method: locked?
-action:
+actions:
   set:
     allow_edit: true
 ```
@@ -237,7 +237,7 @@ name: bulk_discount
 salience: 10
 tags: [pricing, discount]
 no_loop: true
-condition:
+conditions:
   type: all
   children:
     - type: pred
@@ -258,7 +258,7 @@ condition:
       right:
         type: literal
         value: 10
-action:
+actions:
   set:
     discount: 0.15
     discount_reason: "Bulk order discount"
@@ -301,10 +301,10 @@ Convert DSL rules to YAML:
 # Define rule in DSL
 engine = Ruleur.define do
   rule 'example' do
-    match do
+    conditions do
       all?(user(:admin?))
     end
-    execute do
+    actions do
       allow! :access
     end
   end

--- a/docs/examples/index.md
+++ b/docs/examples/index.md
@@ -47,21 +47,21 @@ Complete examples from production systems.
 ```ruby
 engine = Ruleur.define do
   rule 'admin_access' do
-    match do
+    conditions do
       all?(user(:admin?))
     end
 
-    execute do
+    actions do
       set :access, true
     end
   end
 
   rule 'owner_update' do
-    match do
+    conditions do
       all?(user(:owner?, record))
     end
 
-    execute do
+    actions do
       set :update, true
     end
   end
@@ -78,13 +78,13 @@ engine = Ruleur.define do
   rule 'bulk_discount', salience: 10 do
     match { all?(order(:total).gt?(500)) }
 
-    execute { set :discount, 0.15 }
+    actions { set :discount, 0.15 }
   end
 
   rule 'vip_discount', salience: 20 do
     match { all?(customer(:vip?)) }
 
-    execute { set :discount, 0.20 }
+    actions { set :discount, 0.20 }
   end
 end
 
@@ -97,7 +97,7 @@ discount = result[:discount] # Higher salience wins
 ```ruby
 engine = Ruleur.define do
   rule 'can_submit' do
-    match do
+    conditions do
       all?(
         document(:draft?),
         document(:complete?),
@@ -105,13 +105,13 @@ engine = Ruleur.define do
       )
     end
 
-    execute do
+    actions do
       set :submit, true
     end
   end
 
   rule 'can_approve' do
-    match do
+    conditions do
       all?(
         user(:approver?),
         document(:submitted?),
@@ -119,7 +119,7 @@ engine = Ruleur.define do
       )
     end
 
-    execute do
+    actions do
       set :approve, true
     end
   end
@@ -134,7 +134,7 @@ Check conditions and set result flags:
 
 ```ruby
 rule 'validation' do
-  match do
+  conditions do
     all?(
       user(:authenticated?),
       user(:email_verified?),
@@ -142,7 +142,7 @@ rule 'validation' do
     )
   end
 
-  execute { set :user_valid, true }
+  actions { set :user_valid, true }
 end
 ```
 
@@ -152,11 +152,11 @@ Compute values based on inputs:
 
 ```ruby
 rule 'calculate_total' do
-  match do
+  conditions do
     all?(order(:items).present)
   end
 
-  execute do
+  actions do
     order = context[:order]
     subtotal = order.items.sum(&:price)
     tax = subtotal * 0.08
@@ -178,18 +178,18 @@ Rules that depend on other rules' results:
 rule 'step1' do
   match { all?(input(:valid?)) }
 
-  execute { set :step1_complete, true }
+  actions { set :step1_complete, true }
 end
 
 rule 'step2' do
-  match do
+  conditions do
     all?(
       flag(:step1_complete),
       input(:ready?)
     )
   end
 
-  execute { set :step2_complete, true }
+  actions { set :step2_complete, true }
 end
 ```
 

--- a/docs/examples/permissions.md
+++ b/docs/examples/permissions.md
@@ -12,7 +12,7 @@ engine = Ruleur.define do
   rule 'admin_update' do
     match { all?(user(:admin?)) }
 
-    execute { set :update, true }
+    actions { set :update, true }
   end
 end
 
@@ -39,7 +39,7 @@ engine = Ruleur.define do
   rule 'admin_access' do
     match { all?(user(:admin?)) }
 
-    execute { set :admin_access, true }
+    actions { set :admin_access, true }
   end
 end
 
@@ -52,7 +52,7 @@ result[:admin_access] # => true or nil
 ```ruby
 engine = Ruleur.define do
   rule 'staff_access' do
-    match do
+    conditions do
       any?(
         user(:admin?),
         user(:moderator?),
@@ -60,7 +60,7 @@ engine = Ruleur.define do
       )
     end
 
-    execute { set :staff_access, true }
+    actions { set :staff_access, true }
   end
 end
 ```
@@ -72,13 +72,13 @@ end
 ```ruby
 engine = Ruleur.define do
   rule 'owner_update' do
-    match do
+    conditions do
       all?(
         user(:owns?, record),
         not?(record(:locked?))
       )
     end
-    execute do
+    actions do
       set :update, true
     end
   end
@@ -93,7 +93,7 @@ result[:update] # => true or nil
 ```ruby
 engine = Ruleur.define do
   rule 'admin_or_owner_destroy' do
-    match do
+    conditions do
       any?(
         user(:admin?),
         all?(
@@ -102,7 +102,7 @@ engine = Ruleur.define do
         )
       )
     end
-    execute do
+    actions do
       set :destroy, true
     end
   end
@@ -116,35 +116,35 @@ end
 ```ruby
 engine = Ruleur.define do
   rule 'authenticated_show' do
-    match do
+    conditions do
       all?(user(:authenticated?))
     end
-    execute do
+    actions do
       set :show, true
     end
   end
 
   rule 'contributor_update' do
-    match do
+    conditions do
       any?(
         user(:contributor?),
         user(:maintainer?),
         user(:admin?)
       )
     end
-    execute do
+    actions do
       set :update, true
     end
   end
 
   rule 'maintainer_destroy' do
-    match do
+    conditions do
       any?(
         user(:maintainer?),
         user(:admin?)
       )
     end
-    execute do
+    actions do
       set :destroy, true
     end
   end
@@ -158,7 +158,7 @@ end
 ```ruby
 engine = Ruleur.define do
   rule 'standard_approve', salience: 10 do
-    match do
+    conditions do
       all?(
         include?(user_value(:role), %w[approver admin]),
         not?(eq?(record_value(:author_id), user_value(:id))),
@@ -168,20 +168,20 @@ engine = Ruleur.define do
         lt(Time.current.hour, 17)
       )
     end
-    execute do
+    actions do
       set :approve, true
     end
   end
 
   rule 'emergency_approve', salience: 20 do
-    match do
+    conditions do
       all?(
         user(:admin?),
         eq?(record_value(:status), 'pending_approval'),
         flag(:emergency_mode)
       )
     end
-    execute do
+    actions do
       set :approve, true
     end
   end
@@ -195,23 +195,23 @@ end
 ```ruby
 engine = Ruleur.define do
   rule 'basic_features' do
-    match do
+    conditions do
       all?(user(:subscription_active?))
     end
-    execute do
+    actions do
       set :basic_export, true
       set :basic_analytics, true
     end
   end
 
   rule 'premium_features' do
-    match do
+    conditions do
       all?(
         include?(user_value(:subscription_tier), %w[premium enterprise]),
         user(:subscription_active?)
       )
     end
-    execute do
+    actions do
       set :advanced_export, true
       set :custom_reports, true
       set :api_access, true
@@ -219,13 +219,13 @@ engine = Ruleur.define do
   end
 
   rule 'enterprise_features' do
-    match do
+    conditions do
       all?(
         eq?(user_value(:subscription_tier), 'enterprise'),
         user(:subscription_active?)
       )
     end
-    execute do
+    actions do
       set :white_label, true
       set :sso, true
       set :audit_logs, true
@@ -241,7 +241,7 @@ end
 ```ruby
 engine = Ruleur.define do
   rule 'business_hours_access' do
-    match do
+    conditions do
       all?(
         user(:employee?),
         in?([1, 2, 3, 4, 5], [Time.current.wday]),
@@ -249,16 +249,16 @@ engine = Ruleur.define do
         lt(Time.current.hour, 17)
       )
     end
-    execute do
+    actions do
       set :system_access, true
     end
   end
 
   rule 'after_hours_admin' do
-    match do
+    conditions do
       all?(user(:admin?))
     end
-    execute do
+    actions do
       set :system_access, true
     end
   end
@@ -272,58 +272,58 @@ class BlogPolicy
   def self.engine
     @engine ||= Ruleur.define do
       rule 'published_show' do
-        match do
+        conditions do
           all?(record(:published?))
         end
-        execute do
+        actions do
           set :show, true
         end
       end
 
       rule 'own_draft_show' do
-        match do
+        conditions do
           all?(
             user(:owns?, record),
             record(:draft?)
           )
         end
-        execute do
+        actions do
           set :show, true
         end
       end
 
       rule 'own_draft_update' do
-        match do
+        conditions do
           all?(
             user(:owns?, record),
             record(:draft?),
             not?(record(:locked?))
           )
         end
-        execute do
+        actions do
           set :update, true
           set :destroy, true
         end
       end
 
       rule 'editor_update' do
-        match do
+        conditions do
           all?(
             include?(user_value(:role), %w[editor admin]),
             not?(record(:archived?))
           )
         end
-        execute do
+        actions do
           set :update, true
           set :publish, true
         end
       end
 
       rule 'admin_crud' do
-        match do
+        conditions do
           all?(user(:admin?))
         end
-        execute do
+        actions do
           set :show, true
           set :update, true
           set :destroy, true
@@ -442,11 +442,11 @@ With Ruleur, you only define **when a value is set**. If no rule matches, the va
 ```ruby
 engine = Ruleur.define do
   rule 'admin_crud', salience: 100, no_loop: true, tags: [:admin] do
-    match do
+    conditions do
       all?(user(:admin?))
     end
 
-    execute do
+    actions do
       set :show, true
       set :create, true
       set :update, true
@@ -455,14 +455,14 @@ engine = Ruleur.define do
   end
 
   rule 'draft_owner_crud', salience: 50, no_loop: true, tags: %i[ownership draft] do
-    match do
+    conditions do
       all?(
         record(:draft?),
         eq?(record_value(:owner_id), user_value(:id))
       )
     end
 
-    execute do
+    actions do
       set :show, true
       set :update, true
       set :destroy, true
@@ -470,20 +470,20 @@ engine = Ruleur.define do
   end
 
   rule 'review_owner_update', salience: 50, no_loop: true, tags: %i[lifecycle review] do
-    match do
+    conditions do
       all?(
         record(:in_review?),
         eq?(record_value(:owner_id), user_value(:id))
       )
     end
 
-    execute do
+    actions do
       set :update, true
     end
   end
 
   rule 'review_approver_update', salience: 45, no_loop: true, tags: %i[lifecycle review] do
-    match do
+    conditions do
       all?(
         record(:in_review?),
         user(:approver?),
@@ -491,40 +491,40 @@ engine = Ruleur.define do
       )
     end
 
-    execute do
+    actions do
       set :update, true
     end
   end
 
   rule 'published_show', salience: 50, no_loop: true, tags: %i[lifecycle published] do
-    match do
+    conditions do
       all?(record(:published?))
     end
 
-    execute do
+    actions do
       set :show, true
     end
   end
 
   rule 'published_owner_destroy', salience: 45, no_loop: true, tags: %i[lifecycle published] do
-    match do
+    conditions do
       all?(
         record(:published?),
         eq?(record_value(:owner_id), user_value(:id))
       )
     end
 
-    execute do
+    actions do
       set :destroy, true
     end
   end
 
   rule 'owner_crud', salience: 40, no_loop: true, tags: [:ownership] do
-    match do
+    conditions do
       all?(eq?(record_value(:owner_id), user_value(:id)))
     end
 
-    execute do
+    actions do
       set :show, true
       set :update, true
       set :destroy, true
@@ -532,34 +532,34 @@ engine = Ruleur.define do
   end
 
   rule 'department_show', salience: 30, no_loop: true, tags: [:department] do
-    match do
+    conditions do
       all?(
         record(:visible_to_department?),
         eq?(record_value(:department_id), user_value(:department_id))
       )
     end
 
-    execute do
+    actions do
       set :show, true
     end
   end
 
   rule 'shared_show', salience: 25, no_loop: true, tags: [:sharing] do
-    match do
+    conditions do
       all?(record(:shared_with_user))
     end
 
-    execute do
+    actions do
       set :show, true
     end
   end
 
   rule 'public_show', salience: 20, no_loop: true, tags: [:visibility] do
-    match do
+    conditions do
       all?(record(:public?))
     end
 
-    execute do
+    actions do
       set :show, true
     end
   end
@@ -662,22 +662,22 @@ Only set values when conditions are met. Don't use `set :key, false`:
 ```ruby
 # Avoid: Using false values
 rule 'not_authenticated' do
-  match do
+  conditions do
     all?(not?(user(:authenticated?)))
   end
 
-  execute do
+  actions do
     set :update, false
   end
 end
 
 # Better: Only set when true
 rule 'authenticated_update' do
-  match do
+  conditions do
     all?(user(:authenticated?))
   end
 
-  execute do
+  actions do
     set :update, true
   end
 end
@@ -690,28 +690,28 @@ Place cheap/fast checks before expensive ones. This avoids unnecessary work:
 ```ruby
 # Bad: Expensive check first
 rule 'check_permission' do
-  match do
+  conditions do
     all?(
       expensive_database_query(:has_permission?),  # Expensive - do last
       user(:admin?)                                # Cheap - check first
     )
   end
 
-  execute do
+  actions do
     set :update, true
   end
 end
 
 # Good: Cheap checks first
 rule 'check_permission' do
-  match do
+  conditions do
     all?(
       user(:admin?),                              # Cheap - check first
       expensive_database_query(:has_permission?)  # Expensive - only if needed
     )
   end
 
-  execute do
+  actions do
     set :update, true
   end
 end
@@ -723,11 +723,11 @@ Place high-priority rules (like admin bypass) at high salience so they fire firs
 
 ```ruby
 rule 'admin_crud', salience: 100 do
-  match do
+  conditions do
     all?(user(:admin?))
   end
 
-  execute do
+  actions do
     set :show, true
     set :create, true
     set :update, true

--- a/docs/examples/pricing.md
+++ b/docs/examples/pricing.md
@@ -17,19 +17,19 @@ Pricing rules help you:
 ```ruby
 engine = Ruleur.define do
   rule 'vip_discount' do
-    match do
+    conditions do
       all?(customer(:vip?))
     end
-    execute do
+    actions do
       set :discount, 0.10
     end
   end
 
   rule 'bulk_discount' do
-    match do
+    conditions do
       all?(order(:total).gt?(500))
     end
-    execute do
+    actions do
       set :discount, 0.15
     end
   end
@@ -45,25 +45,25 @@ final_price = order.total * (1 - discount)
 ```ruby
 engine = Ruleur.define do
   rule 'base_vip_discount', salience: 10 do
-    match do
+    conditions do
       all?(customer(:vip?))
     end
-    execute do
+    actions do
       set :discount_vip, 0.10
     end
   end
 
   rule 'seasonal_discount', salience: 10 do
-    match do
+    conditions do
       all?(literal(Date.today.month).in([11, 12]))
     end
-    execute do
+    actions do
       set :discount_seasonal, 0.05
     end
   end
 
   rule 'calculate_total_discount', salience: 5 do
-    match do
+    conditions do
       all?(
         any?(
           flag(:discount_vip).present,
@@ -71,7 +71,7 @@ engine = Ruleur.define do
         )
       )
     end
-    execute do
+    actions do
       vip = context[:discount_vip] || 0
       seasonal = context[:discount_seasonal] || 0
 
@@ -90,59 +90,59 @@ end
 ```ruby
 engine = Ruleur.define do
   rule 'tier_bronze', salience: 10 do
-    match do
+    conditions do
       all?(
         order(:quantity).gte?(1),
         order(:quantity).lt?(10)
       )
     end
-    execute do
+    actions do
       set :price_per_unit, 10.00
       set :tier, 'bronze'
     end
   end
 
   rule 'tier_silver', salience: 20 do
-    match do
+    conditions do
       all?(
         order(:quantity).gte?(10),
         order(:quantity).lt?(50)
       )
     end
-    execute do
+    actions do
       set :price_per_unit, 8.50
       set :tier, 'silver'
     end
   end
 
   rule 'tier_gold', salience: 30 do
-    match do
+    conditions do
       all?(
         order(:quantity).gte?(50),
         order(:quantity).lt?(100)
       )
     end
-    execute do
+    actions do
       set :price_per_unit, 7.00
       set :tier, 'gold'
     end
   end
 
   rule 'tier_platinum', salience: 40 do
-    match do
+    conditions do
       all?(order(:quantity).gte?(100))
     end
-    execute do
+    actions do
       set :price_per_unit, 5.50
       set :tier, 'platinum'
     end
   end
 
   rule 'calculate_total', salience: 5 do
-    match do
+    conditions do
       all?(flag(:price_per_unit).present)
     end
-    execute do
+    actions do
       quantity = context[:order].quantity
       price = context[:price_per_unit]
       set :subtotal, quantity * price
@@ -156,13 +156,13 @@ end
 ```ruby
 engine = Ruleur.define do
   rule 'basic_tier' do
-    match do
+    conditions do
       all?(
         customer(:subscription).eq?('basic'),
         customer(:active?)
       )
     end
-    execute do
+    actions do
       set :monthly_price, 29.99
       set :feature_limit, 10
       set :storage_gb, 5
@@ -170,13 +170,13 @@ engine = Ruleur.define do
   end
 
   rule 'pro_tier' do
-    match do
+    conditions do
       all?(
         customer(:subscription).eq?('pro'),
         customer(:active?)
       )
     end
-    execute do
+    actions do
       set :monthly_price, 79.99
       set :feature_limit, 100
       set :storage_gb, 50
@@ -184,13 +184,13 @@ engine = Ruleur.define do
   end
 
   rule 'enterprise_tier' do
-    match do
+    conditions do
       all?(
         customer(:subscription).eq?('enterprise'),
         customer(:active?)
       )
     end
-    execute do
+    actions do
       set :monthly_price, 299.99
       set :feature_limit, Float::INFINITY
       set :storage_gb, 500
@@ -198,10 +198,10 @@ engine = Ruleur.define do
   end
 
   rule 'annual_discount' do
-    match do
+    conditions do
       all?(customer(:billing_period).eq?('annual'))
     end
-    execute do
+    actions do
       monthly = context[:monthly_price]
       annual_discount = monthly * 12 * 0.20
       set :annual_price, (monthly * 12) - annual_discount
@@ -218,23 +218,23 @@ end
 ```ruby
 engine = Ruleur.define do
   rule 'free_shipping_threshold', salience: 100 do
-    match do
+    conditions do
       all?(order(:total).gt?(100))
     end
-    execute do
+    actions do
       set :shipping_cost, 0
       set :free_shipping, true
     end
   end
 
   rule 'local_shipping', salience: 50 do
-    match do
+    conditions do
       all?(
         not?(flag(:free_shipping)),
         order(:distance_miles).lt?(50)
       )
     end
-    execute do
+    actions do
       weight = context[:order].weight_lbs
       base = 5.00
       per_pound = 0.50
@@ -243,14 +243,14 @@ engine = Ruleur.define do
   end
 
   rule 'regional_shipping', salience: 40 do
-    match do
+    conditions do
       all?(
         not?(flag(:free_shipping)),
         order(:distance_miles).gte?(50),
         order(:distance_miles).lt?(500)
       )
     end
-    execute do
+    actions do
       weight = context[:order].weight_lbs
       base = 12.00
       per_pound = 0.75
@@ -259,13 +259,13 @@ engine = Ruleur.define do
   end
 
   rule 'national_shipping', salience: 30 do
-    match do
+    conditions do
       all?(
         not?(flag(:free_shipping)),
         order(:distance_miles).gte?(500)
       )
     end
-    execute do
+    actions do
       weight = context[:order].weight_lbs
       base = 25.00
       per_pound = 1.00
@@ -282,36 +282,36 @@ end
 ```ruby
 engine = Ruleur.define do
   rule 'black_friday', salience: 100 do
-    match do
+    conditions do
       all?(
         literal(Date.today).gte?(literal(Date.new(2026, 11, 24))),
         literal(Date.today).lte?(literal(Date.new(2026, 11, 29)))
       )
     end
-    execute do
+    actions do
       set :discount, 0.25
       set :promo_code, 'BLACKFRIDAY'
     end
   end
 
   rule 'cyber_monday', salience: 100 do
-    match do
+    conditions do
       all?(literal(Date.today).eq?(literal(Date.new(2026, 12, 2))))
     end
-    execute do
+    actions do
       set :discount, 0.30
       set :promo_code, 'CYBERMONDAY'
     end
   end
 
   rule 'first_purchase', salience: 50 do
-    match do
+    conditions do
       all?(
         customer(:first_purchase?),
         not?(flag(:discount).present)
       )
     end
-    execute do
+    actions do
       set :discount, 0.15
       set :promo_code, 'WELCOME15'
     end
@@ -324,26 +324,26 @@ end
 ```ruby
 engine = Ruleur.define do
   rule 'validate_coupon', salience: 100 do
-    match do
+    conditions do
       all?(
         coupon(:valid?),
         coupon(:not_expired?),
         not?(coupon(:used?))
       )
     end
-    execute do
+    actions do
       set :coupon_valid, true
     end
   end
 
   rule 'percentage_coupon' do
-    match do
+    conditions do
       all?(
         flag(:coupon_valid),
         coupon(:type).eq?('percentage')
       )
     end
-    execute do
+    actions do
       discount = context[:coupon].discount_percentage / 100.0
       set :discount, discount
       set :discount_type, 'percentage'
@@ -351,13 +351,13 @@ engine = Ruleur.define do
   end
 
   rule 'fixed_amount_coupon' do
-    match do
+    conditions do
       all?(
         flag(:coupon_valid),
         coupon(:type).eq?('fixed')
       )
     end
-    execute do
+    actions do
       amount = context[:coupon].discount_amount
       set :discount_amount, amount
       set :discount_type, 'fixed'
@@ -365,13 +365,13 @@ engine = Ruleur.define do
   end
 
   rule 'free_shipping_coupon' do
-    match do
+    conditions do
       all?(
         flag(:coupon_valid),
         coupon(:type).eq?('free_shipping')
       )
     end
-    execute do
+    actions do
       set :shipping_cost, 0
       set :free_shipping, true
       set :discount_type, 'free_shipping'
@@ -387,43 +387,43 @@ end
 ```ruby
 engine = Ruleur.define do
   rule 'normal_pricing', salience: 10 do
-    match do
+    conditions do
       all?(demand(:current_load).lt?(70))
     end
-    execute do
+    actions do
       set :surge_multiplier, 1.0
       set :pricing_tier, 'normal'
     end
   end
 
   rule 'moderate_surge', salience: 20 do
-    match do
+    conditions do
       all?(
         demand(:current_load).gte?(70),
         demand(:current_load).lt?(90)
       )
     end
-    execute do
+    actions do
       set :surge_multiplier, 1.5
       set :pricing_tier, 'moderate'
     end
   end
 
   rule 'high_surge', salience: 30 do
-    match do
+    conditions do
       all?(demand(:current_load).gte?(90))
     end
-    execute do
+    actions do
       set :surge_multiplier, 2.0
       set :pricing_tier, 'high'
     end
   end
 
   rule 'apply_surge', salience: 5 do
-    match do
+    conditions do
       all?(flag(:surge_multiplier).present)
     end
-    execute do
+    actions do
       base_price = context[:service].base_price
       multiplier = context[:surge_multiplier]
       set :final_price, base_price * multiplier
@@ -442,10 +442,10 @@ class OrderPricingEngine
     @engine ||= Ruleur.define do
       # Step 1: Calculate base price
       rule 'calculate_base', salience: 100, no_loop: true do
-        match do
+        conditions do
           all?(order(:items).present)
         end
-        execute do
+        actions do
           items = context[:order].items
           subtotal = items.sum { |item| item.price * item.quantity }
           set :subtotal, subtotal
@@ -454,13 +454,13 @@ class OrderPricingEngine
 
       # Step 2: Apply member discounts
       rule 'member_discount', salience: 90 do
-        match do
+        conditions do
           all?(
             customer(:member?),
             customer(:member_tier).in(%w[gold platinum])
           )
         end
-        execute do
+        actions do
           discount = case context[:customer].member_tier
                      when 'gold' then 0.10
                      when 'platinum' then 0.15
@@ -472,10 +472,10 @@ class OrderPricingEngine
 
       # Step 3: Apply bulk discounts
       rule 'bulk_discount', salience: 85 do
-        match do
+        conditions do
           all?(flag(:subtotal).gt?(500))
         end
-        execute do
+        actions do
           subtotal = context[:subtotal]
           discount = if subtotal >= 1000
                        0.20
@@ -490,7 +490,7 @@ class OrderPricingEngine
 
       # Step 4: Calculate discount amount
       rule 'calculate_discount', salience: 80, no_loop: true do
-        match do
+        conditions do
           all?(
             any?(
               flag(:member_discount).present,
@@ -498,7 +498,7 @@ class OrderPricingEngine
             )
           )
         end
-        execute do
+        actions do
           member = context[:member_discount] || 0
           bulk = context[:bulk_discount] || 0
 
@@ -516,10 +516,10 @@ class OrderPricingEngine
 
       # Step 5: Calculate shipping
       rule 'calculate_shipping', salience: 70, no_loop: true do
-        match do
+        conditions do
           all?(flag(:price_after_discount).present)
         end
-        execute do
+        actions do
           price = context[:price_after_discount]
 
           shipping = if price >= 100
@@ -537,13 +537,13 @@ class OrderPricingEngine
 
       # Step 6: Calculate tax
       rule 'calculate_tax', salience: 60, no_loop: true do
-        match do
+        conditions do
           all?(
             flag(:price_after_discount).present,
             order(:tax_rate).present
           )
         end
-        execute do
+        actions do
           price = context[:price_after_discount]
           tax_rate = context[:order].tax_rate
 
@@ -554,14 +554,14 @@ class OrderPricingEngine
 
       # Step 7: Calculate final total
       rule 'calculate_total', salience: 50, no_loop: true do
-        match do
+        conditions do
           all?(
             flag(:price_after_discount).present,
             flag(:shipping_cost).present,
             flag(:tax_amount).present
           )
         end
-        execute do
+        actions do
           price = context[:price_after_discount]
           shipping = context[:shipping_cost]
           tax = context[:tax_amount]
@@ -600,7 +600,7 @@ pricing = OrderPricingEngine.calculate(@order, current_user)
 name: bulk_discount
 salience: 10
 tags: [pricing, discount]
-condition:
+conditions:
   type: pred
   op: greater_than
   left:
@@ -610,7 +610,7 @@ condition:
   right:
     type: literal
     value: 500
-action:
+actions:
   set:
     discount: 0.15
     discount_reason: "Bulk order discount"

--- a/docs/examples/real-world.md
+++ b/docs/examples/real-world.md
@@ -29,26 +29,26 @@ class OrderValidationEngine
     @engine ||= Ruleur.define do
       # Inventory Check
       rule 'check_inventory', salience: 100 do
-        match do
+        conditions do
           all?(
             order(:items).present,
             order(:items_in_stock?)
           )
         end
-        execute do
+        actions do
           set :inventory_valid, true
           set :validation_step, 'inventory_passed'
         end
       end
 
       rule 'insufficient_inventory', salience: 100 do
-        match do
+        conditions do
           all?(
             order(:items).present,
             not?(order(:items_in_stock?))
           )
         end
-        execute do
+        actions do
           items = context[:order].out_of_stock_items
           set :validation_failed, true
           set :error_code, 'INSUFFICIENT_INVENTORY'
@@ -58,24 +58,24 @@ class OrderValidationEngine
 
       # Customer Validation
       rule 'validate_customer', salience: 90 do
-        match do
+        conditions do
           all?(
             flag(:inventory_valid),
             customer(:active?),
             not?(customer(:suspended?))
           )
         end
-        execute do
+        actions do
           set :customer_valid, true
           set :validation_step, 'customer_passed'
         end
       end
 
       rule 'suspended_customer', salience: 90 do
-        match do
+        conditions do
           all?(customer(:suspended?))
         end
-        execute do
+        actions do
           set :validation_failed, true
           set :error_code, 'CUSTOMER_SUSPENDED'
           set :error_message, 'Customer account is suspended'
@@ -84,14 +84,14 @@ class OrderValidationEngine
 
       # Payment Method Validation
       rule 'validate_payment', salience: 80 do
-        match do
+        conditions do
           all?(
             flag(:customer_valid),
             order(:payment_method).present,
             order(:payment_valid?)
           )
         end
-        execute do
+        actions do
           set :payment_valid, true
           set :validation_step, 'payment_passed'
         end
@@ -99,13 +99,13 @@ class OrderValidationEngine
 
       # Regional Restrictions
       rule 'check_shipping_restrictions', salience: 70 do
-        match do
+        conditions do
           all?(
             flag(:payment_valid),
             order(:shipping_address).present
           )
         end
-        execute do
+        actions do
           address = context[:order].shipping_address
           restricted = context[:order].has_restricted_items?(address.country)
 
@@ -122,13 +122,13 @@ class OrderValidationEngine
 
       # Business Days Check
       rule 'business_days_validation', salience: 60 do
-        match do
+        conditions do
           all?(
             flag(:shipping_valid),
             order(:expedited_shipping?)
           )
         end
-        execute do
+        actions do
           today = Date.today
           is_business_day = (1..5).include?(today.wday)
 
@@ -143,7 +143,7 @@ class OrderValidationEngine
 
       # Final Validation
       rule 'order_valid', salience: 10 do
-        match do
+        conditions do
           all?(
             flag(:inventory_valid),
             flag(:customer_valid),
@@ -152,7 +152,7 @@ class OrderValidationEngine
             not?(flag(:validation_failed))
           )
         end
-        execute do
+        actions do
           set :order_valid, true
           set :ready_to_process, true
         end
@@ -210,10 +210,10 @@ class FeatureAccessEngine
     @engine ||= Ruleur.define do
       # Basic Features (All tiers)
       rule 'basic_features', salience: 100 do
-        match do
+        conditions do
           all?(user(:subscription, :active?))
         end
-        execute do
+        actions do
           allow! :dashboard
           allow! :basic_reports
           allow! :profile
@@ -224,13 +224,13 @@ class FeatureAccessEngine
 
       # Pro Features
       rule 'pro_features', salience: 90 do
-        match do
+        conditions do
           all?(
             user(:subscription, :tier).in(%w[pro enterprise]),
             user(:subscription, :active?)
           )
         end
-        execute do
+        actions do
           allow! :advanced_analytics
           allow! :custom_reports
           allow! :api_access
@@ -243,13 +243,13 @@ class FeatureAccessEngine
 
       # Enterprise Features
       rule 'enterprise_features', salience: 80 do
-        match do
+        conditions do
           all?(
             user(:subscription, :tier).eq?('enterprise'),
             user(:subscription, :active?)
           )
         end
-        execute do
+        actions do
           allow! :sso
           allow! :audit_logs
           allow! :white_label
@@ -263,13 +263,13 @@ class FeatureAccessEngine
 
       # Trial Limitations
       rule 'trial_limitations', salience: 110 do
-        match do
+        conditions do
           all?(
             user(:subscription, :trial?),
             user(:subscription, :active?)
           )
         end
-        execute do
+        actions do
           allow! :dashboard
           allow! :basic_reports
           set :max_projects, 1
@@ -280,10 +280,10 @@ class FeatureAccessEngine
 
       # Add-on: Extra Storage
       rule 'storage_addon', salience: 70 do
-        match do
+        conditions do
           all?(user(:has_addon?, 'extra_storage'))
         end
-        execute do
+        actions do
           current_storage = context[:storage_gb] || 5
           set :storage_gb, current_storage + 50
         end
@@ -291,13 +291,13 @@ class FeatureAccessEngine
 
       # Add-on: API Access for Basic Users
       rule 'api_addon', salience: 70 do
-        match do
+        conditions do
           all?(
             user(:subscription, :tier).eq?('basic'),
             user(:has_addon?, 'api_access')
           )
         end
-        execute do
+        actions do
           allow! :api_access
           set :api_rate_limit, 100
         end
@@ -305,13 +305,13 @@ class FeatureAccessEngine
 
       # Usage Limits
       rule 'check_project_limit', salience: 50 do
-        match do
+        conditions do
           all?(
             flag(:max_projects).present,
             user(:projects_count).gte?(flag(:max_projects))
           )
         end
-        execute do
+        actions do
           deny! :create_project
           set :limit_reached, 'projects'
           set :upgrade_required, true
@@ -319,13 +319,13 @@ class FeatureAccessEngine
       end
 
       rule 'check_storage_limit', salience: 50 do
-        match do
+        conditions do
           all?(
             flag(:storage_gb).present,
             user(:storage_used_gb).gte?(flag(:storage_gb))
           )
         end
-        execute do
+        actions do
           deny! :upload_files
           set :limit_reached, 'storage'
           set :upgrade_required, true
@@ -334,10 +334,10 @@ class FeatureAccessEngine
 
       # Expired Subscription
       rule 'expired_subscription', salience: 120 do
-        match do
+        conditions do
           all?(not?(user(:subscription, :active?)))
         end
-        execute do
+        actions do
           allow! :dashboard
           allow! :billing
           deny! :create_project
@@ -399,14 +399,14 @@ class ContentModerationEngine
     @engine ||= Ruleur.define do
       # Trusted User Auto-Approve
       rule 'trusted_user_auto_approve', salience: 100 do
-        match do
+        conditions do
           all?(
             user(:trusted?),
             user(:violations_count).eq?(0),
             content(:type).in(%w[text image])
           )
         end
-        execute do
+        actions do
           set :moderation_action, 'approve'
           set :auto_approved, true
           set :reason, 'Trusted user with clean history'
@@ -415,7 +415,7 @@ class ContentModerationEngine
 
       # Spam Detection
       rule 'spam_detection', salience: 110 do
-        match do
+        conditions do
           all?(
             any?(
               content(:contains_spam_keywords?),
@@ -424,7 +424,7 @@ class ContentModerationEngine
             )
           )
         end
-        execute do
+        actions do
           set :moderation_action, 'reject'
           set :flag_reason, 'Potential spam detected'
           set :notify_user, true
@@ -433,10 +433,10 @@ class ContentModerationEngine
 
       # Profanity Check
       rule 'profanity_check', salience: 105 do
-        match do
+        conditions do
           all?(content(:contains_profanity?))
         end
-        execute do
+        actions do
           severity = context[:content].profanity_severity
 
           if severity >= 8
@@ -451,14 +451,14 @@ class ContentModerationEngine
 
       # New User Content
       rule 'new_user_review', salience: 90 do
-        match do
+        conditions do
           all?(
             user(:account_age_days).lt?(7),
             not?(flag(:auto_approved)),
             not?(flag(:moderation_action).present)
           )
         end
-        execute do
+        actions do
           set :moderation_action, 'review'
           set :flag_reason, 'New user - pending review'
           set :review_priority, 'low'
@@ -467,13 +467,13 @@ class ContentModerationEngine
 
       # Sensitive Content
       rule 'sensitive_content', salience: 95 do
-        match do
+        conditions do
           all?(
             content(:type).in(%w[image video]),
             content(:ai_flagged?)
           )
         end
-        execute do
+        actions do
           confidence = context[:content].ai_confidence
 
           if confidence >= 0.9
@@ -489,13 +489,13 @@ class ContentModerationEngine
 
       # Copyright Claims
       rule 'copyright_check', salience: 100 do
-        match do
+        conditions do
           all?(
             content(:type).in(%w[image video audio]),
             content(:copyright_match?)
           )
         end
-        execute do
+        actions do
           set :moderation_action, 'remove'
           set :flag_reason, 'Copyright violation detected'
           set :dmca_takedown, true
@@ -505,10 +505,10 @@ class ContentModerationEngine
 
       # Rate Limiting
       rule 'rate_limit_exceeded', salience: 120 do
-        match do
+        conditions do
           all?(user(:posts_last_hour).gt?(10))
         end
-        execute do
+        actions do
           set :moderation_action, 'rate_limit'
           set :flag_reason, 'Posting too frequently'
           set :cooldown_minutes, 60
@@ -517,10 +517,10 @@ class ContentModerationEngine
 
       # Default: Queue for Review
       rule 'default_review', salience: 1 do
-        match do
+        conditions do
           all?(not?(flag(:moderation_action).present))
         end
-        execute do
+        actions do
           set :moderation_action, 'review'
           set :flag_reason, 'Standard review process'
           set :review_priority, 'normal'
@@ -587,17 +587,17 @@ class InsurancePolicyEngine
     @engine ||= Ruleur.define do
       # Base Risk Assessment
       rule 'age_risk_low', salience: 100 do
-        match do
+        conditions do
           all?(
             applicant(:age).gte?(25),
             applicant(:age).lte?(60)
           )
         end
-        execute { set :age_risk_score, 0 }
+        actions { set :age_risk_score, 0 }
       end
 
       rule 'age_risk_high', salience: 100 do
-        match do
+        conditions do
           all?(
             any?(
               applicant(:age).lt?(25),
@@ -605,35 +605,35 @@ class InsurancePolicyEngine
             )
           )
         end
-        execute { set :age_risk_score, 20 }
+        actions { set :age_risk_score, 20 }
       end
 
       # Driving History
       rule 'clean_driving_record', salience: 90 do
-        match do
+        conditions do
           all?(
             applicant(:accidents_last_5_years).eq?(0),
             applicant(:violations_last_3_years).eq?(0)
           )
         end
-        execute do
+        actions do
           set :driving_risk_score, 0
           set :safe_driver_discount, 0.15
         end
       end
 
       rule 'moderate_driving_risk', salience: 90 do
-        match do
+        conditions do
           all?(
             applicant(:accidents_last_5_years).in([1, 2]),
             applicant(:violations_last_3_years).lt?(3)
           )
         end
-        execute { set :driving_risk_score, 30 }
+        actions { set :driving_risk_score, 30 }
       end
 
       rule 'high_driving_risk', salience: 90 do
-        match do
+        conditions do
           all?(
             any?(
               applicant(:accidents_last_5_years).gt?(2),
@@ -642,7 +642,7 @@ class InsurancePolicyEngine
             )
           )
         end
-        execute do
+        actions do
           set :driving_risk_score, 100
           set :requires_underwriting, true
         end
@@ -650,35 +650,35 @@ class InsurancePolicyEngine
 
       # Credit Score Impact
       rule 'excellent_credit', salience: 85 do
-        match do
+        conditions do
           all?(
             applicant(:credit_score).gte?(750)
           )
         end
-        execute do
+        actions do
           set :credit_risk_score, -10
           set :credit_discount, 0.10
         end
       end
 
       rule 'poor_credit', salience: 85 do
-        match do
+        conditions do
           all?(
             applicant(:credit_score).lt?(600)
           )
         end
-        execute { set :credit_risk_score, 25 }
+        actions { set :credit_risk_score, 25 }
       end
 
       # Calculate Total Risk Score
       rule 'calculate_risk', salience: 50, no_loop: true do
-        match do
+        conditions do
           all?(
             flag(:age_risk_score).present,
             flag(:driving_risk_score).present
           )
         end
-        execute do
+        actions do
           age = context[:age_risk_score]
           driving = context[:driving_risk_score]
           credit = context[:credit_risk_score] || 0
@@ -690,34 +690,34 @@ class InsurancePolicyEngine
 
       # Eligibility Determination
       rule 'eligible_standard', salience: 40 do
-        match do
+        conditions do
           all?(
             flag(:total_risk_score).lt?(50),
             not?(flag(:requires_underwriting))
           )
         end
-        execute do
+        actions do
           set :eligible, true
           set :policy_tier, 'standard'
         end
       end
 
       rule 'eligible_high_risk', salience: 40 do
-        match do
+        conditions do
           all?(
             flag(:total_risk_score).gte?(50),
             flag(:total_risk_score).lt?(80),
             not?(flag(:requires_underwriting))
           )
         end
-        execute do
+        actions do
           set :eligible, true
           set :policy_tier, 'high_risk'
         end
       end
 
       rule 'requires_manual_review', salience: 40 do
-        match do
+        conditions do
           all?(
             any?(
               flag(:total_risk_score).gte?(80),
@@ -725,7 +725,7 @@ class InsurancePolicyEngine
             )
           )
         end
-        execute do
+        actions do
           set :eligible, false
           set :manual_underwriting_required, true
           set :reason, 'Risk score too high - manual review needed'
@@ -734,13 +734,13 @@ class InsurancePolicyEngine
 
       # Premium Calculation
       rule 'calculate_premium', salience: 30 do
-        match do
+        conditions do
           all?(
             flag(:eligible),
             flag(:policy_tier).present
           )
         end
-        execute do
+        actions do
           base_premium = 1000
           risk_score = context[:total_risk_score]
           tier = context[:policy_tier]

--- a/docs/examples/workflow.md
+++ b/docs/examples/workflow.md
@@ -17,39 +17,39 @@ Workflow rules help you:
 ```ruby
 engine = Ruleur.define do
   rule 'can_submit' do
-    match do
+    conditions do
       all?(
         document(:draft?),
         document(:valid?),
         not?(document(:submitted?))
       )
     end
-    execute do
+    actions do
       allow! :submit
     end
   end
 
   rule 'can_approve' do
-    match do
+    conditions do
       all?(
         user(:approver?),
         document(:submitted?),
         not?(document(:approved?))
       )
     end
-    execute do
+    actions do
       allow! :approve
     end
   end
 
   rule 'can_reject' do
-    match do
+    conditions do
       all?(
         user(:approver?),
         document(:submitted?)
       )
     end
-    execute do
+    actions do
       allow! :reject
     end
   end
@@ -64,14 +64,14 @@ end
 engine = Ruleur.define do
   # Draft -> Submitted
   rule 'submit_document', salience: 100 do
-    match do
+    conditions do
       all?(
         document(:status).eq?('draft'),
         document(:complete?),
         flag(:action_submit)
       )
     end
-    execute do
+    actions do
       call_method document, :update_status, 'submitted'
       set :status_changed, true
       set :new_status, 'submitted'
@@ -80,14 +80,14 @@ engine = Ruleur.define do
 
   # Submitted -> Under Review
   rule 'start_review', salience: 90 do
-    match do
+    conditions do
       all?(
         document(:status).eq?('submitted'),
         user(:reviewer?),
         flag(:action_start_review)
       )
     end
-    execute do
+    actions do
       call_method document, :update_status, 'under_review'
       call_method document, :assign_reviewer, context[:user]
       set :status_changed, true
@@ -97,14 +97,14 @@ engine = Ruleur.define do
 
   # Under Review -> Approved
   rule 'approve_document', salience: 80 do
-    match do
+    conditions do
       all?(
         document(:status).eq?('under_review'),
         user(:approver?),
         flag(:action_approve)
       )
     end
-    execute do
+    actions do
       call_method document, :update_status, 'approved'
       call_method document, :set_approved_by, context[:user]
       set :status_changed, true
@@ -114,7 +114,7 @@ engine = Ruleur.define do
 
   # Under Review -> Rejected
   rule 'reject_document', salience: 80 do
-    match do
+    conditions do
       all?(
         document(:status).eq?('under_review'),
         user(:approver?),
@@ -122,7 +122,7 @@ engine = Ruleur.define do
         flag(:rejection_reason).present
       )
     end
-    execute do
+    actions do
       call_method document, :update_status, 'rejected'
       call_method document, :add_rejection_reason, context[:rejection_reason]
       set :status_changed, true
@@ -132,14 +132,14 @@ engine = Ruleur.define do
 
   # Rejected -> Draft (resubmit)
   rule 'resubmit_document', salience: 70 do
-    match do
+    conditions do
       all?(
         document(:status).eq?('rejected'),
         user(:owns?, document),
         flag(:action_resubmit)
       )
     end
-    execute do
+    actions do
       call_method document, :update_status, 'draft'
       set :status_changed, true
       set :new_status, 'draft'
@@ -156,14 +156,14 @@ end
 engine = Ruleur.define do
   # Step 1: Validate Order
   rule 'validate_order', salience: 100, no_loop: true do
-    match do
+    conditions do
       all?(
         order(:status).eq?('pending'),
         order(:items).present,
         order(:shipping_address).present
       )
     end
-    execute do
+    actions do
       set :order_valid, true
       set :step_validate, 'completed'
     end
@@ -171,13 +171,13 @@ engine = Ruleur.define do
 
   # Step 2: Check Inventory
   rule 'check_inventory', salience: 90, no_loop: true do
-    match do
+    conditions do
       all?(
         flag(:order_valid),
         order(:items_in_stock?)
       )
     end
-    execute do
+    actions do
       set :inventory_available, true
       set :step_inventory, 'completed'
     end
@@ -185,13 +185,13 @@ engine = Ruleur.define do
 
   # Step 3: Calculate Pricing
   rule 'calculate_pricing', salience: 80, no_loop: true do
-    match do
+    conditions do
       all?(
         flag(:inventory_available),
         order(:total).gt?(0)
       )
     end
-    execute do
+    actions do
       order = context[:order]
       discount = calculate_discount(order)
       shipping = calculate_shipping(order)
@@ -205,13 +205,13 @@ engine = Ruleur.define do
 
   # Step 4: Process Payment
   rule 'process_payment', salience: 70, no_loop: true do
-    match do
+    conditions do
       all?(
         flag(:step_pricing).eq?('completed'),
         order(:payment_method).present
       )
     end
-    execute do
+    actions do
       # Payment processing logic
       set :payment_processed, true
       set :step_payment, 'completed'
@@ -220,13 +220,13 @@ engine = Ruleur.define do
 
   # Step 5: Fulfill Order
   rule 'fulfill_order', salience: 60, no_loop: true do
-    match do
+    conditions do
       all?(
         flag(:payment_processed),
         flag(:inventory_available)
       )
     end
-    execute do
+    actions do
       call_method order, :fulfill!
       set :fulfillment_started, true
       set :step_fulfillment, 'completed'
@@ -235,10 +235,10 @@ engine = Ruleur.define do
 
   # Final Step: Complete Order
   rule 'complete_order', salience: 50, no_loop: true do
-    match do
+    conditions do
       all?(flag(:fulfillment_started))
     end
-    execute do
+    actions do
       call_method order, :complete!
       set :order_complete, true
       set :completed_at, Time.current
@@ -254,41 +254,41 @@ end
 ```ruby
 engine = Ruleur.define do
   rule 'technical_approval' do
-    match do
+    conditions do
       all?(
         user(:technical_lead?),
         document(:technical_review_pending?),
         flag(:action_approve_technical)
       )
     end
-    execute do
+    actions do
       call_method document, :set_technical_approval, context[:user]
       set :technical_approved, true
     end
   end
 
   rule 'business_approval' do
-    match do
+    conditions do
       all?(
         user(:business_lead?),
         document(:business_review_pending?),
         flag(:action_approve_business)
       )
     end
-    execute do
+    actions do
       call_method document, :set_business_approval, context[:user]
       set :business_approved, true
     end
   end
 
   rule 'final_approval' do
-    match do
+    conditions do
       all?(
         flag(:technical_approved),
         flag(:business_approved)
       )
     end
-    execute do
+    actions do
       call_method document, :finalize_approval
       set :fully_approved, true
       set :approved_at, Time.current
@@ -305,14 +305,14 @@ end
 engine = Ruleur.define do
   # Small amounts - auto-approve
   rule 'auto_approve_small', salience: 100 do
-    match do
+    conditions do
       all?(
         expense(:amount).lt?(100),
         user(:employee?),
         not?(expense(:approved?))
       )
     end
-    execute do
+    actions do
       call_method expense, :auto_approve!
       set :approved, true
       set :approval_type, 'automatic'
@@ -321,13 +321,13 @@ engine = Ruleur.define do
 
   # Medium amounts - manager approval
   rule 'manager_approval_required', salience: 90 do
-    match do
+    conditions do
       all?(
         expense(:amount).gte?(100),
         expense(:amount).lt?(1000)
       )
     end
-    execute do
+    actions do
       set :approval_required, 'manager'
       set :approval_level, 1
     end
@@ -335,13 +335,13 @@ engine = Ruleur.define do
 
   # Large amounts - director approval
   rule 'director_approval_required', salience: 80 do
-    match do
+    conditions do
       all?(
         expense(:amount).gte?(1000),
         expense(:amount).lt?(10_000)
       )
     end
-    execute do
+    actions do
       set :approval_required, 'director'
       set :approval_level, 2
     end
@@ -349,10 +349,10 @@ engine = Ruleur.define do
 
   # Very large - CFO approval
   rule 'cfo_approval_required', salience: 70 do
-    match do
+    conditions do
       all?(expense(:amount).gte?(10_000))
     end
-    execute do
+    actions do
       set :approval_required, 'cfo'
       set :approval_level, 3
     end
@@ -367,10 +367,10 @@ end
 ```ruby
 engine = Ruleur.define do
   rule 'track_progress', no_loop: true do
-    match do
+    conditions do
       all?(workflow(:in_progress?))
     end
-    execute do
+    actions do
       workflow = context[:workflow]
       completed = workflow.steps.count(&:completed?)
       total = workflow.steps.count
@@ -392,7 +392,7 @@ name: document_approval_flow
 salience: 10
 tags: [workflow, approval]
 no_loop: true
-condition:
+conditions:
   type: all
   children:
     # Document is submitted
@@ -431,7 +431,7 @@ condition:
           recv: { type: ref, root: document }
           method: approved?
 
-action:
+actions:
   set:
     allow_approve: true
     approval_ready: true
@@ -451,14 +451,14 @@ class PurchaseOrderWorkflow
     @engine ||= Ruleur.define do
       # Create Purchase Order
       rule 'create_purchase_order', salience: 100 do
-        match do
+        conditions do
           all?(
             purchase_order(:draft?),
             purchase_order(:valid?),
             flag(:action_create)
           )
         end
-        execute do
+        actions do
           call_method purchase_order, :submit
           set :purchase_order_created, true
           set :status, 'pending_approval'
@@ -467,14 +467,14 @@ class PurchaseOrderWorkflow
 
       # Auto-approve under threshold
       rule 'auto_approve', salience: 90 do
-        match do
+        conditions do
           all?(
             purchase_order(:total).lt?(1000),
             purchase_order(:status).eq?('pending_approval'),
             user(:employee?)
           )
         end
-        execute do
+        actions do
           call_method purchase_order, :auto_approve
           set :approved, true
           set :approval_method, 'automatic'
@@ -483,14 +483,14 @@ class PurchaseOrderWorkflow
 
       # Manager approval
       rule 'manager_review', salience: 80 do
-        match do
+        conditions do
           all?(
             purchase_order(:total).gte?(1000),
             purchase_order(:total).lt?(10_000),
             purchase_order(:status).eq?('pending_approval')
           )
         end
-        execute do
+        actions do
           set :requires_manager_approval, true
           set :approval_level, 'manager'
         end
@@ -498,14 +498,14 @@ class PurchaseOrderWorkflow
 
       # Manager approves
       rule 'manager_approves', salience: 70 do
-        match do
+        conditions do
           all?(
             flag(:requires_manager_approval),
             user(:manager?),
             flag(:action_approve)
           )
         end
-        execute do
+        actions do
           call_method purchase_order, :approve_by, context[:user]
           set :approved, true
           set :approved_by, 'manager'
@@ -514,13 +514,13 @@ class PurchaseOrderWorkflow
 
       # Send to vendor
       rule 'send_to_vendor', salience: 60 do
-        match do
+        conditions do
           all?(
             flag(:approved),
             not?(purchase_order(:sent_to_vendor?))
           )
         end
-        execute do
+        actions do
           call_method purchase_order, :send_to_vendor
           set :sent_to_vendor, true
           set :sent_at, Time.current

--- a/docs/getting-started/first-rule.md
+++ b/docs/getting-started/first-rule.md
@@ -49,24 +49,24 @@ You define rules that set values when conditions are met:
 ```ruby
 engine = Ruleur.define do
   rule 'admin_update' do
-    match do
+    conditions do
       any?(user(:admin?))
     end
 
-    execute do
+    actions do
       set :update, true
     end
   end
 
   rule 'author_draft_update' do
-    match do
+    conditions do
       all?(
         record(:draft?),
         eq?(record_value(:author_id), user_value(:id))
       )
     end
 
-    execute do
+    actions do
       set :update, true
     end
   end
@@ -107,31 +107,31 @@ engine = Ruleur.define do
   rule 'admin_update' do
     match { any?(user(:admin?)) }
 
-    execute { set :update, true }
+    actions { set :update, true }
   end
 
   rule 'author_draft_update' do
-    match do
+    conditions do
       all?(
         record(:draft?),
         eq?(record_value(:author_id), user_value(:id))
       )
     end
 
-    execute do
+    actions do
       set :update, true
     end
   end
 
   rule 'published_requires_admin' do
-    match do
+    conditions do
       all?(
         not?(record(:draft?)),
         user(:admin?)
       )
     end
 
-    execute do
+    actions do
       set :update, true
     end
   end
@@ -167,24 +167,24 @@ end
 
 engine = Ruleur.define do
   rule 'admin_update' do
-    match do
+    conditions do
       any?(user(:admin?))
     end
 
-    execute do
+    actions do
       set :update, true
     end
   end
 
   rule 'author_draft_update' do
-    match do
+    conditions do
       all?(
         record(:draft?),
         eq?(record_value(:author_id), user_value(:id))
       )
     end
 
-    execute do
+    actions do
       set :update, true
     end
   end

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -34,10 +34,10 @@ require 'ruleur'
 
 engine = Ruleur.define do
   rule 'hello' do
-    match do
+    conditions do
       any?(truthy?(true))
     end
-    execute do
+    actions do
       set :greeting, 'Hello Ruleur!'
     end
   end

--- a/docs/guide/advanced.md
+++ b/docs/guide/advanced.md
@@ -11,19 +11,19 @@ This guide covers advanced features and techniques for working with Ruleur, incl
 ```ruby
 engine = Ruleur.define do
   rule 'low_priority', salience: 0 do
-    match do
+    conditions do
       all?(user(:logged_in?))
     end
-    execute do
+    actions do
       set :priority, 'low'
     end
   end
 
   rule 'high_priority', salience: 100 do
-    match do
+    conditions do
       all?(user(:admin?))
     end
-    execute do
+    actions do
       set :priority, 'high'
     end
   end
@@ -103,10 +103,10 @@ Without no-loop, a rule might fire repeatedly if its action makes its condition 
 ```ruby
 # Without no_loop - could fire multiple times!
 rule 'increment_counter' do
-  match do
+  conditions do
     all?(lt(ref(:counter), 10))
   end
-  execute do |ctx|
+  actions do |ctx|
     ctx[:counter] = (ctx[:counter] || 0) + 1
   end
 end
@@ -116,10 +116,10 @@ end
 
 ```ruby
 rule 'increment_counter', no_loop: true do
-  match do
+  conditions do
     all?(lt(ref(:counter), 10))
   end
-  execute do |ctx|
+  actions do |ctx|
     ctx[:counter] = (ctx[:counter] || 0) + 1
   end
 end
@@ -138,23 +138,23 @@ Use `no_loop: true` when:
 
 ```ruby
 rule 'grant_base_permissions', no_loop: true do
-  match do
+  conditions do
     all?(user(:registered?))
   end
-  execute do
+  actions do
     set :view, true
     set :comment, true
   end
 end
 
 rule 'grant_premium_permissions', no_loop: true do
-  match do
+  conditions do
     all?(
       user(:premium?),
       flag(:view) # Depends on previous rule
     )
   end
-  execute do
+  actions do
     set :download, true
     set :export, true
   end
@@ -220,10 +220,10 @@ Monitor execution cycles:
 cycles = 0
 engine = Ruleur.define do
   rule 'count_cycles', no_loop: false do
-    match do
+    conditions do
       all?(lt(ref(:counter), 100))
     end
-    execute do |ctx|
+    actions do |ctx|
       ctx[:counter] = (ctx[:counter] || 0) + 1
       cycles += 1
     end
@@ -241,13 +241,13 @@ Organize rules with tags:
 ```ruby
 engine = Ruleur.define do
   rule 'admin_check', tags: %w[permissions admin] do
-    match do
+    conditions do
       all? # placeholder
     end
   end
 
   rule 'payment_rule', tags: %w[payment validation] do
-    match do
+    conditions do
       all? # placeholder
     end
   end
@@ -272,19 +272,19 @@ Use consistent tag hierarchies:
 
 ```ruby
 rule 'process_user', tags: %w[user permissions] do
-  match do
+  conditions do
     all?(user(:active?))
   end
-  execute do
+  actions do
     set :can_access, true
   end
 end
 
 rule 'process_order', tags: %w[order payment] do
-  match do
+  conditions do
     all?(order(:pending?))
   end
-  execute do
+  actions do
     set :can_charge, true
   end
 end
@@ -351,42 +351,42 @@ Fewer rules = faster execution:
 ```ruby
 # Good - single rule
 rule 'permission_check' do
-  match do
+  conditions do
     any?(
       user(:admin?),
       user(:editor?),
       user(:owner?)
     )
   end
-  execute do
+  actions do
     set :edit, true
   end
 end
 
 # Less efficient - three rules
 rule 'admin_edit' do
-  match do
+  conditions do
     all?(user(:admin?))
   end
-  execute do
+  actions do
     set :edit, true
   end
 end
 
 rule 'editor_edit' do
-  match do
+  conditions do
     all?(user(:editor?))
   end
-  execute do
+  actions do
     set :edit, true
   end
 end
 
 rule 'owner_edit' do
-  match do
+  conditions do
     all?(user(:owner?))
   end
-  execute do
+  actions do
     set :edit, true
   end
 end
@@ -398,7 +398,7 @@ Put cheap, likely-to-fail checks first:
 
 ```ruby
 # Good - cheap check first
-match do
+conditions do
   all?(
     user(:logged_in?), # Fast boolean check
     present?(record_value(:title)), # Fast presence check
@@ -407,7 +407,7 @@ match do
 end
 
 # Less efficient - expensive check first
-match do
+conditions do
   all?(
     expensive_db_query,
     user(:logged_in?)
@@ -467,7 +467,7 @@ Avoid expensive computations in conditions:
 
 ```ruby
 # Bad - computed on every evaluation
-match do
+conditions do
   all?(
     gt?(record_value(:items).sum(&:price), 1000)
   )
@@ -478,7 +478,7 @@ total = recordord.items.sum(&:price)
 ctx = engine.run(user: user, recordord: recordord, total: total)
 
 rule 'high_value_order' do
-  match do
+  conditions do
     all?(gt?(ref(:total), 1000))
   end
 end
@@ -562,7 +562,7 @@ end
 
 # Use in rule
 rule 'age_range_check' do
-  match do
+  conditions do
     all?(
       predicate do
         left = record_value(:age)
@@ -571,7 +571,7 @@ rule 'age_range_check' do
       end
     )
   end
-  execute do
+  actions do
     set :eligible, true
   end
 end

--- a/docs/guide/conditions.md
+++ b/docs/guide/conditions.md
@@ -20,11 +20,11 @@ A **predicate** is the basic building block - it compares two values using an op
 
 ```ruby
 rule 'adult_check' do
-  match do
+  conditions do
     all?(gte(record_value(:age), 18)) # Predicate: recordord.age >= 18
   end
 
-  execute do
+  actions do
     allow! :access
   end
 end
@@ -86,7 +86,7 @@ The `all?` condition evaluates to true only if **all** children are true.
 
 ```ruby
 rule 'restricted_access' do
-  match do
+  conditions do
     all?(
       user(:verified?),
       user(:premium?),
@@ -94,7 +94,7 @@ rule 'restricted_access' do
     )
   end
 
-  execute do
+  actions do
     allow! :vip_access
   end
 end
@@ -110,7 +110,7 @@ Prefer using `match` together with `all?()`/`any?()` to make rule structure expl
 
 ```ruby
 # Using match + all (preferred)
-match do
+conditions do
   all?(
     user(:verified?),
     user(:premium?)
@@ -118,7 +118,7 @@ match do
 end
 
 # Legacy shorthand (still supported):
-match do
+conditions do
   all?(
     user(:verified?),
     user(:premium?)
@@ -133,7 +133,7 @@ The `any?` condition evaluates to true if **at least one** child is true.
 
 ```ruby
 rule 'can_edit' do
-  match do
+  conditions do
     any?(
       user(:admin?),
       user(:editor?),
@@ -141,7 +141,7 @@ rule 'can_edit' do
     )
   end
 
-  execute do
+  actions do
     allow! :edit
   end
 end
@@ -158,11 +158,11 @@ The `not?` condition inverts the result of its child.
 
 ```ruby
 rule 'not_archived' do
-  match do
+  conditions do
     all?(not?(record(:archived?)))
   end
 
-  execute do
+  actions do
     allow! :view
   end
 end
@@ -178,7 +178,7 @@ The real power comes from nesting conditions to express complex logic.
 
 ```ruby
 rule 'complex_update' do
-  match do
+  conditions do
     all?(
       any?(
         user(:admin?),
@@ -190,7 +190,7 @@ rule 'complex_update' do
     )
   end
 
-  execute do
+  actions do
     allow! :update
   end
 end
@@ -202,7 +202,7 @@ end
 
 ```ruby
 rule 'complex_view' do
-  match do
+  conditions do
     any?(
       record(:public?),
       all?(
@@ -212,7 +212,7 @@ rule 'complex_view' do
     )
   end
 
-  execute do
+  actions do
     allow! :view
   end
 end
@@ -224,7 +224,7 @@ end
 
 ```ruby
 rule 'publish_permission' do
-  match do
+  conditions do
     any?(
       user(:admin?),
       all?(
@@ -238,7 +238,7 @@ rule 'publish_permission' do
     )
   end
 
-  execute do
+  actions do
     allow! :publish
   end
 end
@@ -252,7 +252,7 @@ For simple truthy checks, use the DSL helpers:
 
 ```ruby
 rule 'simple' do
-  match do
+  conditions do
     all?(
       user(:admin?), # Checks user.admin? is truthy
       record(:published?) # Checks recordord.published? is truthy
@@ -267,7 +267,7 @@ For comparisons and complex checks:
 
 ```ruby
 rule 'explicit' do
-  match do
+  conditions do
     all?(
       gte(record_value(:age), 18),
       include?(record_value(:status), %w[active trial])
@@ -282,7 +282,7 @@ Combine both approaches:
 
 ```ruby
 rule 'mixed' do
-  match do
+  conditions do
     all?(
       user(:verified?), # Shortcut
       gte(record_value(:subscription_level), 3), # Explicit
@@ -397,7 +397,7 @@ For complex logic that doesn't fit the operator model, use `predicate` blocks:
 
 ```ruby
 rule 'custom_logic' do
-  match do
+  conditions do
     all?(
       predicate do |ctx|
         user = ctx[:user]
@@ -410,7 +410,7 @@ rule 'custom_logic' do
     )
   end
 
-  execute do
+  actions do
     allow! :purchase
   end
 end
@@ -440,14 +440,14 @@ ctx = engine.run(recordord: my_recordord, user: current_user)
 Composite conditions short-circuit for efficiency:
 
 ```ruby
-match do
+conditions do
   all?(
     expensive_check,   # Evaluated first
     cheap_check        # Not evaluated if expensive_check() returns false
   )
 end
 
-match do
+conditions do
   any?(
     cheap_check,       # Evaluated first
     expensive_check    # Not evaluated if cheap_check() returns true
@@ -463,7 +463,7 @@ Check permissions in priority order:
 
 ```ruby
 rule 'permission_cascade' do
-  match do
+  conditions do
     any?(
       user(:admin?), # Highest priority
       all?(user(:editor?), record(:draft?)), # Medium priority
@@ -471,7 +471,7 @@ rule 'permission_cascade' do
     )
   end
 
-  execute do
+  actions do
     allow! :edit
   end
 end
@@ -483,7 +483,7 @@ Combine feature flags with business logic:
 
 ```ruby
 rule 'new_feature' do
-  match do
+  conditions do
     all?(
       flag(:new_feature_enabled), # Feature flag
       user(:premium?), # Business rule
@@ -491,7 +491,7 @@ rule 'new_feature' do
     )
   end
 
-  execute do
+  actions do
     set :use_new_feature, true
   end
 end
@@ -503,7 +503,7 @@ Different access levels based on user tier:
 
 ```ruby
 rule 'vip_access' do
-  match do
+  conditions do
     all?(
       user(:vip?),
       any?(
@@ -514,13 +514,13 @@ rule 'vip_access' do
     )
   end
 
-  execute do
+  actions do
     allow! :access
   end
 end
 
 rule 'premium_access' do
-  match do
+  conditions do
     all?(
       user(:premium?),
       any?(
@@ -530,20 +530,20 @@ rule 'premium_access' do
     )
   end
 
-  execute do
+  actions do
     allow! :access
   end
 end
 
 rule 'basic_access' do
-  match do
+  conditions do
     all?(
       user(:registered?),
       record(:public?)
     )
   end
 
-  execute do
+  actions do
     allow! :access
   end
 end
@@ -555,27 +555,27 @@ Use flags set by earlier rules:
 
 ```ruby
 rule 'check_eligibility', salience: 10 do
-  match do
+  conditions do
     all?(
       gte(record_value(:age), 18),
       user(:verified?)
     )
   end
 
-  execute do
+  actions do
     allow! :eligible
   end
 end
 
 rule 'grant_access', salience: 0 do
-  match do
+  conditions do
     all?(
       flag(:eligible), # Depends on previous rule
       record(:active?)
     )
   end
 
-  execute do
+  actions do
     allow! :access
   end
 end
@@ -586,7 +586,7 @@ end
 Conditions serialize to YAML for storage:
 
 ```yaml
-condition:
+conditions:
   type: any
   children:
     - type: pred
@@ -626,7 +626,7 @@ Break complex conditions into smaller rules:
 ```ruby
 # Good - clear intent
 rule 'eligible_for_discount' do
-  match do
+  conditions do
     all?(
       user(:premium?),
       gte(record_value(:total), 100)
@@ -637,7 +637,7 @@ end
 
 # Hard to read
 rule 'complex' do
-  match do
+  conditions do
     all?(
       any?(
         all?(user(:premium?), gte(record_value(:total), 100)),
@@ -655,7 +655,7 @@ Put cheap, likely-to-fail checks first:
 
 ```ruby
 # Good - cheap check first
-match do
+conditions do
   all?(
     user(:logged_in?), # Fast, often false
     expensive_database_check
@@ -663,7 +663,7 @@ match do
 end
 
 # Less efficient
-match do
+conditions do
   all?(
     expensive_database_check,
     user(:logged_in?)
@@ -677,12 +677,12 @@ end
 # Good
 is_adult = gte(record_value(:age), 18)
 is_verified = user(:verified?)
-match do
+conditions do
   all?(is_adult, is_verified)
 end
 
 # Less clear
-match do
+conditions do
   all?(gte(record_value(:age), 18), user(:verified?))
 end
 ```
@@ -693,7 +693,7 @@ More than 3 levels deep gets hard to follow. Break into multiple rules:
 
 ```ruby
 # Too deep (4 levels)
-match do
+conditions do
   any?(
     a,
     all?(
@@ -708,25 +708,25 @@ end
 
 # Better - split into rules
 rule 'check_complex_1' do
-  match do
+  conditions do
     all?(d, e, any?(f, g))
   end
-  execute do
+  actions do
     set :complex_1, true
   end
 end
 
 rule 'check_complex_2' do
-  match do
+  conditions do
     any?(c, flag(:complex_1))
   end
-  execute do
+  actions do
     set :complex_2, true
   end
 end
 
 rule 'final_check' do
-  match do
+  conditions do
     any?(a, all?(b, flag(:complex_2)))
   end
   allow! :access
@@ -758,7 +758,7 @@ puts condition.evaluate(ctx) # => true or false
 
 ```ruby
 # Add presence checks
-match do
+conditions do
   all?(
     present?(record_value(:user)),
     eq?(record_value(:user).call(:role), 'admin')
@@ -781,7 +781,7 @@ end
 
 ```ruby
 # This short-circuits
-match do
+conditions do
   all?(
     cheap_check, # If false, stops here
     expensive_check

--- a/docs/guide/dsl-basics.md
+++ b/docs/guide/dsl-basics.md
@@ -9,14 +9,14 @@ require 'ruleur'
 
 engine = Ruleur.define do
   rule 'admin_create', no_loop: true do
-    match do
+    conditions do
       any?(
         user(:admin?),
         all?(record(:updatable?), record(:draft?))
       )
     end
 
-    execute do
+    actions do
       set :create, true
     end
   end
@@ -57,12 +57,12 @@ Each rule has:
 
 ```ruby
 rule 'rule_name', salience: 10, tags: ['permissions'], no_loop: true do
-  match do
+  conditions do
     all?
     # conditions go here
   end
 
-  execute do
+  actions do
     set :create, true
   end
 end
@@ -145,24 +145,24 @@ This is useful for chaining rules - one rule sets `:create`, another checks it:
 
 ```ruby
 rule 'admin_create' do
-  match do
+  conditions do
     any?(user(:admin?))
   end
 
-  execute do
+  actions do
     set :create, true
   end
 end
 
 rule 'draft_update' do
-  match do
+  conditions do
     all?(
       flag(:create),
       record(:draft?)
     )
   end
 
-  execute do
+  actions do
     set :update, true
   end
 end
@@ -176,7 +176,7 @@ Conditions determine when a rule fires. Use `match` with `all`/`any` builders or
 
 ```ruby
 rule 'admin_update' do
-  match do
+  conditions do
     all?(
       user(:admin?),
       record(:published?),
@@ -184,7 +184,7 @@ rule 'admin_update' do
     )
   end
 
-  execute do
+  actions do
     set :update, true
   end
 end
@@ -196,7 +196,7 @@ All conditions must be truthy for the rule to fire.
 
 ```ruby
 rule 'editor_show' do
-  match do
+  conditions do
     any?(
       user(:admin?),
       record(:public?),
@@ -204,7 +204,7 @@ rule 'editor_show' do
     )
   end
 
-  execute do
+  actions do
     set :show, true
   end
 end
@@ -218,7 +218,7 @@ You can nest `all` and `any` within `when_all` or `when_any`:
 
 ```ruby
 rule 'editor_update' do
-  match do
+  conditions do
     all?(
       any?(
         user(:admin?),
@@ -231,7 +231,7 @@ rule 'editor_update' do
     )
   end
 
-  execute do
+  actions do
     set :update, true
   end
 end
@@ -243,14 +243,14 @@ For more complex comparisons, use operators directly:
 
 ```ruby
 rule 'premium_purchase' do
-  match do
+  conditions do
     all?(
       gte(record_value(:age), 18),
       eq?(record_value(:country), 'US'),
       includes(literal(%w[active trial]), record_value(:status))
     )
   end
-  execute do
+  actions do
     set :purchase, true
   end
 end
@@ -266,10 +266,10 @@ Actions define what happens when a rule fires. Use the `set` method or `action` 
 
 ```ruby
 rule 'set_discount' do
-  match do
+  conditions do
     all?(user(:premium?))
   end
-  execute do
+  actions do
     set :discount, 0.20
   end
 end
@@ -279,10 +279,10 @@ end
 
 ```ruby
 rule 'set_defaults' do
-  match do
+  conditions do
     all?(record(:new?))
   end
-  execute do
+  actions do
     assert(
       status: 'draft',
       priority: 'low',
@@ -298,10 +298,10 @@ For more complex logic, use an `action` block:
 
 ```ruby
 rule 'calculate_total' do
-  match do
+  conditions do
     all?(record(:items))
   end
-  execute do |ctx|
+  actions do |ctx|
     items = ctx[:record].items
     total = items.sum(&:price)
     tax = total * 0.1
@@ -316,10 +316,10 @@ The `action` method provides a block for executing code:
 
 ```ruby
 rule 'apply_discount' do
-  match do
+  conditions do
     all?(user(:premium?))
   end
-  execute do |ctx|
+  actions do |ctx|
     ctx[:discount] = 0.20
   end
 end
@@ -349,12 +349,12 @@ Rules can reference any context key using `ref`:
 
 ```ruby
 rule 'check_custom' do
-  match do
+  conditions do
     all?(
       eq?(ref(:custom_value), 123)
     )
   end
-  execute do
+  actions do
     set :custom_check, true
   end
 end
@@ -380,10 +380,10 @@ end
 
 engine = Ruleur.define do
   rule 'admin_crud', salience: 100 do
-    match do
+    conditions do
       all?(user(:admin?))
     end
-    execute do
+    actions do
       set :create, true
       set :show, true
       set :update, true
@@ -392,39 +392,39 @@ engine = Ruleur.define do
   end
 
   rule 'editor_create_update', salience: 50 do
-    match do
+    conditions do
       all?(
         user(:editor?),
         record(:draft?)
       )
     end
-    execute do
+    actions do
       set :create, true
       set :update, true
     end
   end
 
   rule 'owner_update' do
-    match do
+    conditions do
       all?(
         record(:draft?),
         not?(record(:locked?)),
         eq?(record_value(:owner_id), user_value(:id))
       )
     end
-    execute do
+    actions do
       set :update, true
     end
   end
 
   rule 'editor_published_update' do
-    match do
+    conditions do
       all?(
         record(:published?),
         any?(user(:admin?), user(:editor?))
       )
     end
-    execute do
+    actions do
       set :update, true
     end
   end
@@ -460,19 +460,19 @@ Each rule should have a single responsibility:
 
 ```ruby
 rule 'admin_create' do
-  match do
+  conditions do
     all?(user(:admin?))
   end
-  execute do
+  actions do
     set :create, true
   end
 end
 
 rule 'verified_user_create' do
-  match do
+  conditions do
     all?(user(:verified?))
   end
-  execute do
+  actions do
     set :create, true
   end
 end
@@ -484,25 +484,25 @@ Higher salience rules fire first:
 
 ```ruby
 rule 'set_default_discount', salience: 0 do
-  execute do
+  actions do
     set :discount, 0.0
   end
 end
 
 rule 'apply_premium_discount', salience: 10 do
-  match do
+  conditions do
     all?(user(:premium?))
   end
-  execute do
+  actions do
     set :discount, 0.15
   end
 end
 
 rule 'apply_vip_discount', salience: 20 do
-  match do
+  conditions do
     all?(user(:vip?))
   end
-  execute do
+  actions do
     set :discount, 0.30
   end
 end
@@ -514,10 +514,10 @@ If a rule's action could make its own condition true again, use `no_loop`:
 
 ```ruby
 rule 'increment_counter', no_loop: true do
-  match do
+  conditions do
     all?(lt(ref(:counter), 100))
   end
-  execute do |ctx|
+  actions do |ctx|
     ctx[:counter] = (ctx[:counter] || 0) + 1
   end
 end

--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -40,12 +40,12 @@ Salience, no-loop, tracing, and performance optimization.
 
 ```ruby
 # Permission check
-match do
+conditions do
   any?(user(:admin?), record(:public?))
 end
 
 # Ownership check
-match do
+conditions do
   all?(
     eq?(record_value(:owner_id), user_value(:id)),
     record(:active?)
@@ -53,7 +53,7 @@ match do
 end
 
 # Range check
-match do
+conditions do
   all?(
     gte?(record_value(:price), 100),
     lte?(record_value(:price), 1000)

--- a/docs/guide/operators.md
+++ b/docs/guide/operators.md
@@ -18,12 +18,12 @@ Checks if two values are equal using Ruby's `==` operator.
 
 ```ruby
 rule 'adult_only' do
-  match do
+  conditions do
     all?(
       eq?(record_value(:age), 18)
     )
   end
-  execute do
+  actions do
     allow! :access
   end
 end
@@ -31,7 +31,7 @@ end
 
 **YAML:**
 ```yaml
-condition:
+conditions:
   type: pred
   op: eq
   left:
@@ -56,12 +56,12 @@ Checks if two values are not equal using Ruby's `!=` operator.
 
 ```ruby
 rule 'exclude_archived' do
-  match do
+  conditions do
     all?(
       not_eq?(record_value(:status), 'archived')
     )
   end
-  execute do
+  actions do
     allow! :view
   end
 end
@@ -80,12 +80,12 @@ Checks if left value is greater than right value. Returns `false` if either valu
 
 ```ruby
 rule 'senior_discount' do
-  match do
+  conditions do
     all?(
       gt?(record_value(:age), 65)
     )
   end
-  execute do
+  actions do
     set :discount, 0.15
   end
 end
@@ -107,12 +107,12 @@ Checks if left value is greater than or equal to right value. Returns `false` if
 
 ```ruby
 rule 'voting_age' do
-  match do
+  conditions do
     all?(
       gte?(record_value(:age), 18)
     )
   end
-  execute do
+  actions do
     allow! :vote
   end
 end
@@ -132,12 +132,12 @@ Checks if left value is less than right value. Returns `false` if either value i
 
 ```ruby
 rule 'child_ticket' do
-  match do
+  conditions do
     all?(
       lt?(record_value(:age), 12)
     )
   end
-  execute do
+  actions do
     set :ticket_price, 5.00
   end
 end
@@ -157,12 +157,12 @@ Checks if left value is less than or equal to right value. Returns `false` if ei
 
 ```ruby
 rule 'standard_shipping' do
-  match do
+  conditions do
     all?(
       lte?(record_value(:weight), 50)
     )
   end
-  execute do
+  actions do
     set :shipping_method, 'standard'
   end
 end
@@ -184,12 +184,12 @@ Checks if left value is included in the right collection. The right operand must
 
 ```ruby
 rule 'valid_status' do
-  match do
+  conditions do
     all?(
       include?(record_value(:status), %w[draft pending published])
     )
   end
-  execute do
+  actions do
     set :edit, true
   end
 end
@@ -207,12 +207,12 @@ Checks if left collection includes the right value. The left operand must respon
 
 ```ruby
 rule 'has_permission' do
-  match do
+  conditions do
     all?(
       includes(record_value(:permissions), 'admin')
     )
   end
-  execute do
+  actions do
     allow! :delete
   end
 end
@@ -233,12 +233,12 @@ Checks if a string matches a regular expression pattern.
 
 ```ruby
 rule 'email_domain_check' do
-  match do
+  conditions do
     all?(
       matches(record_value(:email), literal(/@example\.com$/))
     )
   end
-  execute do
+  actions do
     set :internal_user, true
   end
 end
@@ -265,12 +265,12 @@ Checks if a value is truthy (not `nil` and not `false`).
 
 ```ruby
 rule 'published_only' do
-  match do
+  conditions do
     all?(
       truthy?(record(:published?))
     )
   end
-  execute do
+  actions do
     allow! :view
   end
 end
@@ -301,12 +301,12 @@ Checks if a value is falsy (`nil` or `false`).
 
 ```ruby
 rule 'unpublished_draft' do
-  match do
+  conditions do
     all?(
       falsy?(record(:published?))
     )
   end
-  execute do
+  actions do
     allow! :edit
   end
 end
@@ -327,12 +327,12 @@ Checks if a value is present (not `nil` and not empty). Similar to Rails' `prese
 
 ```ruby
 rule 'requires_description' do
-  match do
+  conditions do
     all?(
       present?(record_value(:description))
     )
   end
-  execute do
+  actions do
     allow! :publish
   end
 end
@@ -360,12 +360,12 @@ Checks if a value is blank (`nil` or empty). Similar to Rails' `blank?`.
 
 ```ruby
 rule 'set_default_title' do
-  match do
+  conditions do
     all?(
       blank?(record_value(:title))
     )
   end
-  execute do
+  actions do
     set :title, 'Untitled'
   end
 end
@@ -395,13 +395,13 @@ The simplest way to use operators with the DSL helpers:
 
 ```ruby
 rule 'simple_check' do
-  match do
+  conditions do
     all?(
       record(:admin?), # truthy check on record.admin?
       user(:verified?) # truthy check on user.verified?
     )
   end
-  execute do
+  actions do
     allow! :access
   end
 end
@@ -413,13 +413,13 @@ For more complex comparisons, use operators direcordtly:
 
 ```ruby
 rule 'age_and_status' do
-  match do
+  conditions do
     all?(
       gte?(record_value(:age), 18),
       include?(record_value(:status), %w[active premium])
     )
   end
-  execute do
+  actions do
     set :purchase, true
   end
 end
@@ -429,7 +429,7 @@ end
 
 ```ruby
 rule 'complex_eligibility' do
-  match do
+  conditions do
     all?(
       gte?(record_value(:age), 21), # Age >= 21
       include?(record_value(:country), %w[US CA]), # Country is US or CA
@@ -438,7 +438,7 @@ rule 'complex_eligibility' do
       not_eq?(record_value(:status), 'banned') # Not banned
     )
   end
-  execute do
+  actions do
     set :vip_access, true
   end
 end
@@ -474,7 +474,7 @@ end
 
 # Use in a rule
 rule 'age_range' do
-  match do
+  conditions do
     all?(
       predicate do
         left = record_value(:age)
@@ -483,7 +483,7 @@ rule 'age_range' do
       end
     )
   end
-  execute do
+  actions do
     allow! :insure
   end
 end
@@ -499,12 +499,12 @@ Comparison operators (`gt`, `gte`, `lt`, `lte`) return `false` when either opera
 
 ```ruby
 rule 'safe_comparison' do
-  match do
+  conditions do
     all?(
       gt?(record_value(:age), 18) # Returns false if age is nil
     )
   end
-  execute do
+  actions do
     allow! :access
   end
 end
@@ -526,7 +526,7 @@ Ensure types match when using comparison operators:
 ```ruby
 # Good
 rule 'numeric_check' do
-  match do
+  conditions do
     all?(
       gt?(record_value(:age).to_i, 18) # Coerce in DSL if needed
     )
@@ -550,7 +550,7 @@ Choose the operator that best expresses your intent:
 ```ruby
 # Good - clear intent
 rule 'has_role' do
-  match do
+  conditions do
     all?(
       includes(record_value(:roles), 'admin')
     )
@@ -559,7 +559,7 @@ end
 
 # Less clear - works but awkward
 rule 'has_role' do
-  match do
+  conditions do
     all?(
       eq?(record_value(:roles).include?('admin'), true)
     )
@@ -574,14 +574,14 @@ For simple boolean checks, use the helpers:
 ```ruby
 # Good - concise
 rule 'admin_check' do
-  match do
+  conditions do
     all?(user(:admin?))
   end
 end
 
 # Verbose
 rule 'admin_check' do
-  match do
+  conditions do
     all?(
       truthy?(ref(:user).call(:admin?))
     )
@@ -596,7 +596,7 @@ When comparing actual values, use the `_val` variants:
 ```ruby
 # Good
 rule 'status_check' do
-  match do
+  conditions do
     all?(
       eq?(record_value(:status), 'published')
     )
@@ -605,7 +605,7 @@ end
 
 # Wrong - record(:status) checks truthiness, not value
 rule 'status_check' do
-  match do
+  conditions do
     all?(
       record(:status) # This checks if status is truthy, not if it equals "published"
     )
@@ -619,14 +619,14 @@ Use `present`/`blank` to handle nil values explicitly:
 
 ```ruby
 rule 'requires_fields' do
-  match do
+  conditions do
     all?(
       present?(record_value(:title)),
       present?(record_value(:description)),
       gte?(record_value(:price), 0)
     )
   end
-  execute do
+  actions do
     allow! :publish
   end
 end
@@ -638,7 +638,7 @@ For clarity, use literal values direcordtly:
 
 ```ruby
 rule 'status_check' do
-  match do
+  conditions do
     all?(
       include?(record_value(:status), %w[draft pending published])
     )

--- a/docs/guide/persistence.md
+++ b/docs/guide/persistence.md
@@ -85,19 +85,19 @@ repo.delete('allow_create')
 # Create some rules
 engine = Ruleur.define do
   rule 'admin_access' do
-    match do
+    conditions do
       all?(user(:admin?))
     end
-    execute do
+    actions do
       set :access, true
     end
   end
 
   rule 'user_access' do
-    match do
+    conditions do
       all?(user(:logged_in?))
     end
-    execute do
+    actions do
       set :view, true
     end
   end
@@ -186,10 +186,10 @@ repo = Ruleur::Persistence::ActiveRecordRepository.new(model_class: MyRule)
 # Define rules
 engine = Ruleur.define do
   rule 'permission_rule', tags: ['permissions'] do
-    match do
+    conditions do
       all?(user(:admin?))
     end
-    execute do
+    actions do
       set :delete, true
     end
   end
@@ -288,10 +288,10 @@ require 'ruleur'
 # Define rule
 engine = Ruleur.define do
   rule 'allow_create', salience: 10, tags: ['permissions'] do
-    match do
+    conditions do
       any?(user(:admin?), record(:draft?))
     end
-    execute do
+    actions do
       set :create, true
     end
   end
@@ -541,10 +541,10 @@ RSpec.describe 'Permission System' do
     # Create rule
     engine = Ruleur.define do
       rule 'admin_access' do
-        match do
+        conditions do
           all?(user(:admin?))
         end
-        execute do
+        actions do
           set :access, true
         end
       end
@@ -639,7 +639,7 @@ rules = repository.all
 
 ```ruby
 # Won't serialize
-execute do |ctx|
+actions do |ctx|
   puts 'Hello' # Arbitrary code
   ctx[:result] = 'something'
 end

--- a/docs/guide/validation.md
+++ b/docs/guide/validation.md
@@ -42,11 +42,11 @@ Validates a complete `Ruleur::Rule` object with structural, semantic, and option
 ```ruby
 rule = Ruleur.define do
   rule 'test_rule' do
-    match do
+    conditions do
       all?(user(:admin?))
     end
 
-    execute do
+    actions do
       allow! :delete
     end
   end
@@ -213,11 +213,11 @@ Record = Struct.new(:status)
 
 rule = Ruleur.define do
   rule 'admin_access' do
-    match do
+    conditions do
       all?(user(:admin))
     end
 
-    execute do
+    actions do
       allow! :access
     end
   end
@@ -248,11 +248,11 @@ end
 ```ruby
 rule = Ruleur.define do
   rule 'broken_rule' do
-    match do
+    conditions do
       all?(user(:nonexistent_method)) # This will fail
     end
 
-    execute do
+    actions do
       allow! :access
     end
   end

--- a/docs/guide/yaml-rules.md
+++ b/docs/guide/yaml-rules.md
@@ -41,9 +41,9 @@ name: rule_name
 salience: 0          # Optional: priority (default 0)
 tags: []             # Optional: array of tags
 no_loop: false       # Optional: prevent infinite loops
-condition:
+conditions:
   # Condition tree (see below)
-action:
+actions:
   # Action specification (see below)
 ```
 
@@ -56,7 +56,7 @@ tags:
   - permissions
   - admin
 no_loop: true
-condition:
+conditions:
   type: pred
   op: truthy
   left:
@@ -68,7 +68,7 @@ condition:
     method: admin?
     args: []
   right: null
-action:
+actions:
   set:
     allow_access: true
 ```
@@ -80,7 +80,7 @@ action:
 Evaluates a comparison between two values:
 
 ```yaml
-condition:
+conditions:
   type: pred
   op: eq              # Operator: eq, ne, gt, gte, lt, lte, truthy, etc.
   left:
@@ -94,7 +94,7 @@ condition:
 All child conditions must be true (AND logic):
 
 ```yaml
-condition:
+conditions:
   type: all
   children:
     - type: pred
@@ -112,7 +112,7 @@ condition:
 At least one child condition must be true (OR logic):
 
 ```yaml
-condition:
+conditions:
   type: any
   children:
     - type: pred
@@ -136,7 +136,7 @@ condition:
 Negates a condition:
 
 ```yaml
-condition:
+conditions:
   type: not
   child:
     type: pred
@@ -185,7 +185,7 @@ args: []               # Optional: method arguments
 Currently, only `set` actions are supported for YAML rules:
 
 ```yaml
-action:
+actions:
   set:
     allow_create: true
     allow_update: false
@@ -205,7 +205,7 @@ tags:
   - permissions
   - create
 no_loop: true
-condition:
+conditions:
   type: any
   children:
     # Admin can always create
@@ -245,7 +245,7 @@ condition:
             method: draft?
             args: []
           right: null
-action:
+actions:
   set:
     allow_create: true
 ```
@@ -258,7 +258,7 @@ salience: 5
 tags:
   - workflow
   - approval
-condition:
+conditions:
   type: all
   children:
     # Amount less than 1000
@@ -283,7 +283,7 @@ condition:
           root: invoice
         method: reviewed?
       right: null
-action:
+actions:
   set:
     auto_approved: true
     approval_status: approved
@@ -297,10 +297,10 @@ You can convert DSL-defined rules to YAML:
 # Define rule with DSL
 engine = Ruleur.define do
   rule 'my_rule', salience: 10 do
-    match do
+    conditions do
       any?(user(:admin?))
     end
-    execute do
+    actions do
       allow! :access
     end
   end
@@ -334,9 +334,9 @@ salience: 10
 tags:
   - permissions
 no_loop: true
-condition:
+conditions:
   # ...
-action:
+actions:
   # ...
 ```
 
@@ -431,7 +431,7 @@ tags:
   - edit
 no_loop: true
 
-condition:
+conditions:
   type: any
   children:
     # Rule 1: Admins can always edit
@@ -464,7 +464,7 @@ condition:
             method: draft?
           right: null
 
-action:
+actions:
   set:
     allow_edit: true
 ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -60,25 +60,25 @@ require 'ruleur'
 
 engine = Ruleur.define do
   rule 'admin_create', no_loop: true do
-    match do
+    conditions do
       any?(
         user(:admin?),
         all?(record(:updatable?), record(:draft?))
       )
     end
-    execute do
+    actions do
       set :create, true
     end
   end
 
   rule 'draft_update', no_loop: true do
-    match do
+    conditions do
       all?(
         record(:draft?),
         flag(:create)
       )
     end
-    execute do
+    actions do
       set :update, true
     end
   end

--- a/lib/ruleur/dsl.rb
+++ b/lib/ruleur/dsl.rb
@@ -81,15 +81,15 @@ module Ruleur
         @conds << predicate(&)
       end
 
-      # New DSL entrypoints: prefer `match do ... end` to collect conditions
-      # and `execute do ... end` to declare the action block. These are
+      # New DSL entrypoints: prefer `conditions do ... end` to collect conditions
+      # and `actions do ... end` to declare the action block. These are
       # thin adapters that keep backward compatibility with existing
       # `when_all`/`when_any` helpers.
-      def match(&block)
+      def conditions(&block)
         instance_eval(&block) if block
       end
 
-      def execute(&)
+      def actions(&)
         action(&)
       end
 

--- a/lib/ruleur/persistence/serializer.rb
+++ b/lib/ruleur/persistence/serializer.rb
@@ -13,8 +13,8 @@ module Ruleur
           salience: rule.salience,
           tags: rule.tags,
           no_loop: rule.no_loop,
-          condition: node_to_h(rule.condition),
-          action: rule.action_spec # serialized action spec only
+          conditions: node_to_h(rule.condition),
+          actions: rule.action_spec # serialized action spec only
         }
       end
 
@@ -72,8 +72,8 @@ module Ruleur
           salience: hash[:salience] || hash['salience'],
           tags: hash[:tags] || hash['tags'],
           no_loop: hash[:no_loop] || hash['no_loop'],
-          condition: node_from_h(hash[:condition] || hash['condition']),
-          action_spec: hash[:action] || hash['action']
+          condition: node_from_h(hash[:conditions] || hash['conditions']),
+          action_spec: hash[:actions] || hash['actions']
         )
       end
 

--- a/lib/ruleur/persistence/yaml_loader.rb
+++ b/lib/ruleur/persistence/yaml_loader.rb
@@ -149,14 +149,14 @@ module Ruleur
 
         # Check required fields
         errors << 'Missing required field: name' unless hash[:name]
-        errors << 'Missing required field: condition' unless hash[:condition]
-        errors << 'Missing required field: action' unless hash[:action]
+        errors << 'Missing required field: conditions' unless hash[:conditions]
+        errors << 'Missing required field: actions' unless hash[:actions]
 
         # Validate condition structure
-        errors.concat(validate_condition_structure(hash[:condition])) if hash[:condition]
+        errors.concat(validate_condition_structure(hash[:conditions])) if hash[:conditions]
 
         # Validate action structure
-        errors.concat(validate_action_structure(hash[:action])) if hash[:action]
+        errors.concat(validate_action_structure(hash[:actions])) if hash[:actions]
 
         errors
       end

--- a/lib/ruleur/validation/rule_validator.rb
+++ b/lib/ruleur/validation/rule_validator.rb
@@ -57,10 +57,10 @@ module Ruleur
         validate_required_fields(rule_hash, result)
 
         # Validate condition structure
-        validate_condition_hash(rule_hash[:condition], result) if rule_hash[:condition]
+        validate_condition_hash(rule_hash[:conditions], result) if rule_hash[:conditions]
 
         # Validate action structure
-        validate_action_hash(rule_hash[:action], result) if rule_hash[:action]
+        validate_action_hash(rule_hash[:actions], result) if rule_hash[:actions]
 
         result
       end
@@ -87,8 +87,8 @@ module Ruleur
 
       def validate_required_fields(hash, result)
         result.add_error('Missing required field: name') unless hash[:name]
-        result.add_error('Missing required field: condition') unless hash[:condition]
-        result.add_error('Missing required field: action') unless hash[:action]
+        result.add_error('Missing required field: conditions') unless hash[:conditions]
+        result.add_error('Missing required field: actions') unless hash[:actions]
       end
 
       # rubocop:disable Metrics/MethodLength

--- a/spec/fixtures/rules/allow_create.yml
+++ b/spec/fixtures/rules/allow_create.yml
@@ -6,7 +6,7 @@ tags:
   - permissions
   - create
 no_loop: true
-condition:
+conditions:
   type: any
   children:
     - type: pred
@@ -44,6 +44,6 @@ condition:
             method: draft?
             args: []
           right: null
-action:
+actions:
   set:
     allow_create: true

--- a/spec/fixtures/rules/allow_update.yml
+++ b/spec/fixtures/rules/allow_update.yml
@@ -6,7 +6,7 @@ tags:
   - permissions
   - update
 no_loop: true
-condition:
+conditions:
   type: all
   children:
     - type: pred
@@ -53,6 +53,6 @@ condition:
                 root: allow_create
                 path: []
               right: null
-action:
+actions:
   set:
     allow_update: true

--- a/spec/fixtures/rules/invalid_operator.yml
+++ b/spec/fixtures/rules/invalid_operator.yml
@@ -3,7 +3,7 @@ name: invalid_operator
 salience: 0
 tags: []
 no_loop: false
-condition:
+conditions:
   type: pred
   op: unknown_operator
   left:
@@ -11,6 +11,6 @@ condition:
     root: value
     path: []
   right: 10
-action:
+actions:
   set:
     result: true

--- a/spec/fixtures/rules/invalid_syntax.yml
+++ b/spec/fixtures/rules/invalid_syntax.yml
@@ -1,11 +1,11 @@
 # Invalid YAML syntax - missing colon
 name invalid_syntax
 salience: 0
-condition:
+conditions:
   type: pred
   op: eq
   left: value
   right: 10
-action:
+actions:
   set:
     result: true

--- a/spec/fixtures/rules/missing_condition.yml
+++ b/spec/fixtures/rules/missing_condition.yml
@@ -1,6 +1,6 @@
 # Invalid rule - missing required field 'condition'
 name: missing_condition
 salience: 0
-action:
+actions:
   set:
     result: true

--- a/spec/fixtures/rules/simple_flag_rule.yml
+++ b/spec/fixtures/rules/simple_flag_rule.yml
@@ -3,7 +3,7 @@ name: simple_flag_rule
 salience: 0
 tags: []
 no_loop: false
-condition:
+conditions:
   type: pred
   op: eq
   left:
@@ -11,6 +11,6 @@ condition:
     root: status
     path: []
   right: active
-action:
+actions:
   set:
     approved: true

--- a/spec/ruleur/persistence/serializer_spec.rb
+++ b/spec/ruleur/persistence/serializer_spec.rb
@@ -8,8 +8,8 @@ RSpec.describe Ruleur::Persistence::Serializer do
       rule = not_rule
 
       serialized = described_class.rule_to_h(rule)
-      expect(serialized[:condition][:type]).to eq('not')
-      expect(serialized[:condition][:child]).to be_a(Hash)
+      expect(serialized[:conditions][:type]).to eq('not')
+      expect(serialized[:conditions][:child]).to be_a(Hash)
     end
 
     it 'deserializes Not nodes' do

--- a/spec/ruleur/persistence/yaml_loader_spec.rb
+++ b/spec/ruleur/persistence/yaml_loader_spec.rb
@@ -92,12 +92,12 @@ RSpec.describe Ruleur::Persistence::YAMLLoader do
     it 'handles symbols in YAML' do
       yaml = <<~YAML
         name: symbol_test
-        condition:
+        conditions:
           type: pred
           op: :eq
           left: :value
           right: :active
-        action:
+        actions:
           set:
             status: :done
       YAML
@@ -255,12 +255,12 @@ RSpec.describe Ruleur::Persistence::YAMLLoader do
     it 'validates correcordt YAML string' do
       yaml = <<~YAML
         name: valid_rule
-        condition:
+        conditions:
           type: pred
           op: eq
           left: value
           right: 10
-        action:
+        actions:
           set:
             result: true
       YAML
@@ -273,12 +273,12 @@ RSpec.describe Ruleur::Persistence::YAMLLoader do
 
     it 'detects missing name' do
       yaml = <<~YAML
-        condition:
+        conditions:
           type: pred
           op: eq
           left: value
           right: 10
-        action:
+        actions:
           set:
             result: true
       YAML
@@ -292,10 +292,10 @@ RSpec.describe Ruleur::Persistence::YAMLLoader do
     it 'detects invalid condition type' do
       yaml = <<~YAML
         name: invalid_cond_type
-        condition:
+        conditions:
           type: unknown_type
           data: test
-        action:
+        actions:
           set:
             result: true
       YAML
@@ -309,9 +309,9 @@ RSpec.describe Ruleur::Persistence::YAMLLoader do
     it 'detects missing children in composite conditions' do
       yaml = <<~YAML
         name: missing_children
-        condition:
+        conditions:
           type: all
-        action:
+        actions:
           set:
             result: true
       YAML
@@ -360,7 +360,7 @@ RSpec.describe Ruleur::Persistence::YAMLLoader do
       salience: 5
       tags: []
       no_loop: false
-      condition:
+      conditions:
         type: pred
         op: eq
         left:
@@ -368,7 +368,7 @@ RSpec.describe Ruleur::Persistence::YAMLLoader do
           root: status
           path: []
         right: active
-      action:
+      actions:
         set:
           result: true
     YAML
@@ -378,7 +378,7 @@ RSpec.describe Ruleur::Persistence::YAMLLoader do
     <<~YAML
       name: test_salience
       salience: 5
-      condition:
+      conditions:
         type: pred
         op: eq
         left:
@@ -386,7 +386,7 @@ RSpec.describe Ruleur::Persistence::YAMLLoader do
           root: status
           path: []
         right: active
-      action:
+      actions:
         set:
           result: true
     YAML

--- a/spec/ruleur/validation_spec.rb
+++ b/spec/ruleur/validation_spec.rb
@@ -305,8 +305,8 @@ RSpec.describe Ruleur::Validation do
     it 'validates rule hash before deserialization' do
       rule_hash = {
         name: 'test',
-        condition: { type: 'pred', op: 'eq', left: 'x', right: 5 },
-        action: { set: { y: 10 } }
+        conditions: { type: 'pred', op: 'eq', left: 'x', right: 5 },
+        actions: { set: { y: 10 } }
       }
 
       result = validator.validate_hash(rule_hash)
@@ -318,15 +318,15 @@ RSpec.describe Ruleur::Validation do
 
       result = validator.validate_hash(rule_hash)
       expect(result.valid?).to be(false)
-      expect(result.errors).to include(/Missing required field: condition/)
-      expect(result.errors).to include(/Missing required field: action/)
+      expect(result.errors).to include(/Missing required field: conditions/)
+      expect(result.errors).to include(/Missing required field: actions/)
     end
 
     it 'detects invalid condition type in hash' do
       rule_hash = {
         name: 'test',
-        condition: { type: 'invalid_type' },
-        action: { set: { y: 10 } }
+        conditions: { type: 'invalid_type' },
+        actions: { set: { y: 10 } }
       }
 
       result = validator.validate_hash(rule_hash)
@@ -392,8 +392,8 @@ RSpec.describe Ruleur::Validation do
     it 'provides validate_hash shortcut' do
       hash = {
         name: 'test',
-        condition: { type: 'pred', op: 'eq', left: 'x', right: 5 },
-        action: { set: { y: 10 } }
+        conditions: { type: 'pred', op: 'eq', left: 'x', right: 5 },
+        actions: { set: { y: 10 } }
       }
 
       result = described_class.validate_hash(hash)


### PR DESCRIPTION
Unify DSL method names and YAML keys to use plural forms:
- DSL: `match` → `conditions`, `execute` → `actions`
- YAML: `condition:` → `conditions:`, `action:` → `actions:`

Update all spec fixtures, inline YAML strings, and doc examples to use the new plural keys consistently.